### PR TITLE
Clarify the save/load setting process

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -86,6 +86,7 @@
                 "rect",
                 "renderer",
                 "sqr",
+                "textarea",
                 "typeof",
                 "uint",
                 "un",

--- a/app/settings.js
+++ b/app/settings.js
@@ -96,10 +96,10 @@ const getRandomSeed = () => Math.random().toString(36).slice(2);
 export const settings = {
   core: {
     height: window.innerHeight - 2 * TANK_PADDING - EXTRA_BUFFER,
-    energy: 3500000,
-    moteSpawnRate: 4,
+    energy: 3000000,
+    moteSpawnRate: 16,
     seed: getRandomSeed(),
-    startingBodies: 75,
+    startingBodies: 50,
     temperature: 30,
     volatility: 100,
     width: window.innerWidth - UI_WIDTH - 2 * TANK_PADDING - EXTRA_BUFFER,
@@ -107,7 +107,7 @@ export const settings = {
   bodies: {
     minRadius: 10,
     moteColor: '#792',
-    moteRadius: 8,
+    moteRadius: 5,
     moteCalorieAdjustment: 2,
     moteSpeedAdjustment: 0.03,
     spawningEnergyAdjustment: 0.75,
@@ -128,11 +128,11 @@ export const settings = {
     percentSpikeGenes: 0.05,
   },
   simulation: {
-    maxBodies: 800,
+    maxBodies: 500,
     spikeHighlightTime: 167,
   },
   spikes: {
-    baseSpikeDrain: 2500,
+    baseSpikeDrain: 10000,
     drainLengthExponent: 1.2,
     spikeWidth: 6,
   },
@@ -140,10 +140,10 @@ export const settings = {
     massCalorieExponent: 0.66, // Idealized Kleiber's law
     percentDiesAt: 0.5,
     percentSpawnsAt: 2,
-    upkeepPerSpike: 8,
+    upkeepPerSpike: 16,
     upkeepPerLength: 1,
     baseUpkeepAdjustment: 0.075, // Adjust so "average" use is ~15 cal/sec
-    spikeUpkeepAdjustment: 200, // Adjust so cost of four is about equal to mass cost
+    spikeUpkeepAdjustment: 250, // Adjust so cost of four is about equal to mass cost
   },
 };
 

--- a/app/view/interface.js
+++ b/app/view/interface.js
@@ -1,7 +1,6 @@
 import {
   settings,
   updateSetting,
-  addUpdateListener,
   getSavedSettings,
   loadSettings,
   restoreDefaultSettings,
@@ -51,7 +50,7 @@ const TOOL_TIPS = {
   TEMPERATE: 'A warmer tank increases meeba metabolism, they will feed and die faster',
   VOLATILITY: 'The more volatile meeba genes, the more mutations their children will inherit',
   DEBUG: 'Warning! These internal simulation settings can have extreme affects',
-  LOAD: 'Copy this text to share your settings, paste text to load saved settings',
+  LOAD: 'Copy this text string to share your settings, paste to load saved settings',
 };
 
 const debugSettings = () => {
@@ -102,18 +101,20 @@ const sizeSettings = () => {
 };
 
 const settingsLoader = () => {
-  const saveStringInput = input('Paste a saved settings string');
-  addUpdateListener(() => {
-    const saved = getSavedSettings();
-    if (saved) {
-      saveStringInput.value = saved;
-    }
+  const saveStringInput = e('textarea', {
+    placeholder: 'Click "Get" to retrieve saved settings,\nclick "Load" to load new settings...',
+    rows: 5,
+    style: { width: '95%' },
   });
 
   return row(
-    header('Load Settings', { title: TOOL_TIPS.LOAD }),
+    header('Save/Load Settings', { title: TOOL_TIPS.LOAD }),
     saveStringInput,
+    button('Get', () => {
+      saveStringInput.value = getSavedSettings() || '';
+    }),
     button('Load', withValue(saveStringInput, loadSettings)),
+    button('Restore Defaults', restoreDefaultSettings),
   );
 };
 
@@ -141,7 +142,6 @@ export const getInterface = ({ pause, resume, reset }) => (
     setting('volatility', 'Gene Volatility', TOOL_TIPS.VOLATILITY),
     debugSettings(),
     settingsLoader(),
-    row(button('Restore Default Settings', restoreDefaultSettings)),
     e('div', { style: { 'margin-top': '2em' } },
       e('small', {},
         e('em', {},


### PR DESCRIPTION
Replaces the simple text input with a more involved textarea and set of buttons. Should make it more clear to users how to save and load their settings.

Also includes some tweaks to the default settings to make the simulation a little more dynamic, in particular a 4x increase to spike drain and a 4x increase in the spawn rate of (smaller) motes.

This will complete the UI project.