### PR TITLE
Add diagnostic tools and fix offscreen death

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -52,6 +52,7 @@
                 "concatted",
                 "const",
                 "corge",
+                "csv",
                 "ctx",
                 "deactivator",
                 "delventhal",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -87,6 +87,7 @@
                 "renderer",
                 "sqr",
                 "textarea",
+                "timestamp",
                 "typeof",
                 "uint",
                 "un",

--- a/app/main.js
+++ b/app/main.js
@@ -83,24 +83,21 @@ let snapshots = [];
 let nextSnapshot = Infinity;
 let snapshotFrequency = 0;
 
-/** @param {number} lastTick */
-const simulate = (lastTick) => {
+/**
+ * @param {number} lastTick
+ * @returns {function(number): void}
+ */
+const run = (lastTick) => (thisTick) => {
   if (isRunning) {
-    const thisTick = performance.now();
     MeebaFarm.bodies = simulateFrame(MeebaFarm.bodies, lastTick, thisTick);
+    renderFrame(MeebaFarm.bodies);
 
     if (thisTick > nextSnapshot) {
       nextSnapshot = thisTick + snapshotFrequency;
       snapshots.push(getSnapshot(thisTick, MeebaFarm.bodies));
     }
 
-    setTimeout(() => simulate(thisTick), 8);
-  }
-};
-const render = () => {
-  if (isRunning) {
-    renderFrame(MeebaFarm.bodies);
-    requestAnimationFrame(render);
+    requestAnimationFrame(run(thisTick));
   }
 };
 
@@ -119,8 +116,9 @@ MeebaFarm.pause = () => {
 MeebaFarm.resume = () => {
   if (!isRunning) {
     isRunning = true;
-    simulate(performance.now());
-    requestAnimationFrame(render);
+    requestAnimationFrame((thisTick) => {
+      requestAnimationFrame(run(thisTick));
+    });
   }
 };
 MeebaFarm.reset = () => {

--- a/app/meebas/genome.js
+++ b/app/meebas/genome.js
@@ -7,6 +7,7 @@ import {
   filter,
   range,
   findIndexes,
+  chunkBy,
   flatten,
   concatBytes,
 } from '../utils/arrays.js';
@@ -250,15 +251,6 @@ const transposeItems = (arr, chance) => {
 };
 
 /**
- * Splits a genome into sub-arrays by control byte
- *
- * @param {Uint8Array} genome
- * @returns {Uint8Array[]}
- */
-const splitGenome = genome => findControlIndexes(genome)
-  .map((index, i, indexes) => genome.slice(index, indexes[i + 1]));
-
-/**
  * Joins an array of gene bytes into one Uint8Array
  *
  * @param {Uint8Array[]} geneArray
@@ -277,7 +269,7 @@ export const replicateGenome = genome => pipe(genome)
   .into(filter, () => rand() >= dynamic.chanceDropByte)
   .into(repeatItems, dynamic.chanceRepeatByte)
   .into(transposeItems, dynamic.chanceTransposeByte)
-  .into(splitGenome)
+  .into(chunkBy, findControlIndexes)
   .into(filter, () => rand() >= dynamic.chanceDropGene)
   .into(repeatItems, dynamic.chanceRepeatGene)
   .into(transposeItems, dynamic.chanceTransposeGene)

--- a/app/simulation.js
+++ b/app/simulation.js
@@ -45,6 +45,7 @@ import {
  * @typedef {import('./utils/physics.js').Velocity} Velocity
  */
 
+const MAX_TIME_PER_FRAME = 0.1;
 const MAX_SEPARATION_ATTEMPTS = 10;
 
 const { core, bodies: bodySettings, simulation: fixed } = settings;
@@ -365,7 +366,7 @@ export const separateBodies = (bodies) => {
  * @returns {Body[]} - new array with inactive bodies removed
  */
 export const simulateFrame = (bodies, start, stop) => {
-  const delay = (stop - start) / 1000;
+  const delay = Math.min((stop - start) / 1000, MAX_TIME_PER_FRAME);
 
   const calcMove = getMoveCalculator(delay);
   const bounceWall = getWallBouncer(delay);

--- a/app/utils/arrays.js
+++ b/app/utils/arrays.js
@@ -42,6 +42,21 @@ export const findIndexes = (arr, predicate) => arr
   .filter(index => index !== -1);
 
 /**
+ * Creates a new 2D array based on a predicate which identifies which elements
+ * should start a new chunk
+ *
+ * @param {array} arr - the array to chunk
+ * @param {function(any): boolean} predicate
+ * @returns {array[]}
+ */
+export const chunkBy = (arr, predicate) => {
+  const rawIndexes = findIndexes(arr, predicate);
+  const indexes = rawIndexes[0] === 0 ? rawIndexes : [0, ...rawIndexes];
+
+  return indexes.map((index, i) => arr.slice(index, indexes[i + 1]));
+};
+
+/**
  * Groups the items in an array into sub-arrays by function output
  *
  * @param {array} arr - the array to group

--- a/app/utils/arrays.js
+++ b/app/utils/arrays.js
@@ -27,9 +27,8 @@ export const flatten = arr => arr.reduce((flat, nested) => flat.concat(nested), 
  * @param {number} size - the size of each chunk
  * @returns {array[]}
  */
-export const chunk = (arr, size) => range(Math.ceil(arr.length / 2))
+export const chunk = (arr, size) => range(Math.ceil(arr.length / size))
   .map(i => arr.slice(i * size, (i + 1) * size));
-
 
 /**
  * Finds the indexes of all items which match a predicate

--- a/app/utils/diagnostics.js
+++ b/app/utils/diagnostics.js
@@ -70,3 +70,28 @@ export const getSnapshot = (timestamp, bodies) => {
     averageMoteSpeed: avg(motes, mote => mote.velocity.speed),
   };
 };
+
+/**
+ * @param {array} arr
+ * @returns {string}
+ */
+const stringify = arr => JSON.stringify(arr).slice(1, -1);
+
+/**
+ * Generates a CSV spring from an array of objects with identical properties
+ *
+ * @param {array} objArray
+ * @returns {string}
+ */
+export const toCsv = (objArray) => {
+  if (objArray.length === 0) {
+    return '';
+  }
+
+  const keys = Object.keys(objArray[0]).sort();
+  const csValues = objArray
+    .map(obj => stringify(keys.map(key => obj[key])))
+    .join('\n');
+
+  return `${stringify(keys)}\n${csValues}`;
+};

--- a/app/utils/diagnostics.js
+++ b/app/utils/diagnostics.js
@@ -1,0 +1,72 @@
+import {
+  flatten,
+  groupBy,
+} from './arrays.js';
+
+/**
+ * @typedef Snapshot
+ *
+ * @prop {number} timestamp
+ * @prop {number} meebas
+ * @prop {number} motes
+ * @prop {number} spikes
+ * @prop {number} calories
+ * @prop {number} averageSize
+ * @prop {number} averageSpikes
+ * @prop {number} averageSpikeLength
+ * @prop {number} averageUpkeep
+ * @prop {number} averageSpeed
+ * @prop {number} averageMoteSpeed
+ */
+
+/**
+ * @typedef {import('../simulation.js').Body} Body
+ */
+
+/**
+ * @template T
+ * @param {T[]} arr
+ * @param {function(T): number} getValue
+ * @returns {number}
+ */
+const sum = (arr, getValue) => arr.reduce((total, item) => total + getValue(item), 0);
+
+/**
+ * @template T
+ * @param {T[]} arr
+ * @param {function(T): number} getValue
+ * @returns {number}
+ */
+const avg = (arr, getValue) => sum(arr, getValue) / arr.length;
+
+/**
+ * @param {Body} body
+ * @returns {'meebas'|'motes'}
+ */
+const isMeebaOrMote = body => (body.dna ? 'meebas' : 'motes');
+
+/**
+ * Generate a report about the current state of the simulation
+ *
+ * @param {number} timestamp - the timestamp for this report
+ * @param {Body[]} bodies - the currently simulated bodies
+ * @returns {Snapshot}
+ */
+export const getSnapshot = (timestamp, bodies) => {
+  const { meebas, motes } = groupBy(bodies, isMeebaOrMote);
+  const spikes = flatten(meebas.map(meeba => meeba.spikes));
+
+  return {
+    timestamp,
+    meebas: meebas.length,
+    motes: motes.length,
+    spikes: spikes.length,
+    calories: sum(bodies, body => body.vitals.calories),
+    averageSize: avg(meebas, meeba => meeba.mass),
+    averageSpikes: avg(meebas, meeba => meeba.spikes.length),
+    averageSpikeLength: avg(spikes, spike => spike.length),
+    averageUpkeep: avg(meebas, meeba => meeba.vitals.upkeep),
+    averageSpeed: avg(meebas, meeba => meeba.velocity.speed),
+    averageMoteSpeed: avg(motes, mote => mote.velocity.speed),
+  };
+};

--- a/tests/app/simulation.test.js
+++ b/tests/app/simulation.test.js
@@ -62,16 +62,16 @@ describe('Simulation methods', () => {
         y: 50,
         velocity: {
           angle: 0,
-          speed: 10,
+          speed: 100,
         },
       };
 
-      let bodies = simulateFrame([body], 0, 1000);
+      let bodies = simulateFrame([body], 0, 100);
       expect(bodies[0].x).to.equal(60);
       expect(bodies[0].y).to.equal(50);
 
-      bodies = simulateFrame(bodies, 1000, 2000);
-      bodies = simulateFrame(bodies, 2000, 3000);
+      bodies = simulateFrame(bodies, 100, 200);
+      bodies = simulateFrame(bodies, 200, 300);
       expect(bodies[0].x).to.equal(80);
       expect(bodies[0].y).to.equal(50);
     });
@@ -85,14 +85,14 @@ describe('Simulation methods', () => {
         y: 50,
         velocity: {
           angle: 0.5,
-          speed: 10,
+          speed: 100,
         },
       };
 
-      const bodies = simulateFrame([body], 0, 1000);
+      const bodies = simulateFrame([body], 0, 100);
 
       expect(bodies[0].velocity.angle).to.equal(0);
-      expect(bodies[0].velocity.speed).to.equal(10);
+      expect(bodies[0].velocity.speed).to.equal(100);
     });
 
     it('should simulate body collisions', () => {
@@ -104,7 +104,7 @@ describe('Simulation methods', () => {
         y: 50,
         velocity: {
           angle: 0,
-          speed: 10,
+          speed: 100,
         },
       };
 
@@ -116,17 +116,35 @@ describe('Simulation methods', () => {
         y: 50,
         velocity: {
           angle: 0.5,
-          speed: 10,
+          speed: 100,
         },
       };
 
-      const bodies = simulateFrame([body1, body2], 0, 1000);
+      const bodies = simulateFrame([body1, body2], 0, 100);
 
       expect(bodies[0].velocity.angle).to.equal(0.5);
-      expect(bodies[0].velocity.speed).to.equal(10);
+      expect(bodies[0].velocity.speed).to.equal(100);
 
       expect(bodies[1].velocity.angle).to.equal(0);
-      expect(bodies[1].velocity.speed).to.equal(10);
+      expect(bodies[1].velocity.speed).to.equal(100);
+    });
+
+    it('should throttle frames to be no longer than 100ms', () => {
+      const body = {
+        ...getRandomBody(),
+        radius: 10,
+        mass: getCircleArea(10),
+        x: 50,
+        y: 50,
+        velocity: {
+          angle: 0,
+          speed: 100,
+        },
+      };
+
+      const bodies = simulateFrame([body], 0, 1000);
+      expect(bodies[0].x).to.equal(60);
+      expect(bodies[0].y).to.equal(50);
     });
   });
 });

--- a/tests/app/utils/arrays.test.js
+++ b/tests/app/utils/arrays.test.js
@@ -9,6 +9,7 @@ const {
   flatten,
   chunk,
   findIndexes,
+  chunkBy,
   groupBy,
   concatBytes,
   toBytes,
@@ -91,6 +92,18 @@ describe('Array utils', () => {
       const indexes = findIndexes([3, 1, 4, 1, 5, 9, 2], n => n > 3);
 
       expect(indexes).to.deep.equal([2, 4, 5]);
+    });
+  });
+
+  describe('chunkBy', () => {
+    it('should chunk an array based on a predicate that identifies a leading value', () => {
+      const chunked = chunkBy([1, 2, 3, 4], n => n % 2 === 0);
+      expect(chunked).to.deep.equal([[1], [2, 3], [4]]);
+    });
+
+    it('should not create an empty chunk if the first element passes the predicate', () => {
+      const chunked = chunkBy([2, 3, 4, 5], n => n % 2 === 0);
+      expect(chunked).to.deep.equal([[2, 3], [4, 5]]);
     });
   });
 

--- a/tests/app/utils/arrays.test.js
+++ b/tests/app/utils/arrays.test.js
@@ -81,13 +81,13 @@ describe('Array utils', () => {
   });
 
   describe('findIndexes', () => {
-    it('should find an index that matches a predicate', () => {
+    it('should find a single index that matches a predicate', () => {
       const indexes = findIndexes(['foo', 'bar', 'baz'], item => item === 'bar');
 
       expect(indexes).to.deep.equal([1]);
     });
 
-    it('should find an index that matches a predicate', () => {
+    it('should find multiple indexes that match a predicate', () => {
       const indexes = findIndexes([3, 1, 4, 1, 5, 9, 2], n => n > 3);
 
       expect(indexes).to.deep.equal([2, 4, 5]);

--- a/tests/app/utils/arrays.test.js
+++ b/tests/app/utils/arrays.test.js
@@ -70,6 +70,14 @@ describe('Array utils', () => {
     it('should include any extra elements in the final chunk', () => {
       expect(chunk([1, 2, 3, 4], 3)).to.deep.equal([[1, 2, 3], [4]]);
     });
+
+    it('should create single item arrays if passed a size of 1', () => {
+      expect(chunk([1, 2, 3, 4], 1)).to.deep.equal([[1], [2], [3], [4]]);
+    });
+
+    it('should create a single chunk if the size is greater than the array length', () => {
+      expect(chunk([1, 2, 3, 4], 5)).to.deep.equal([[1, 2, 3, 4]]);
+    });
   });
 
   describe('findIndexes', () => {

--- a/tests/app/utils/diagnostics.test.js
+++ b/tests/app/utils/diagnostics.test.js
@@ -1,0 +1,216 @@
+'use strict';
+
+const { expect } = require('chai');
+const {
+  getSnapshot,
+} = require('./diagnostics.common.js');
+
+const TEST_BODIES = [
+  {
+    dna: 'F09849F044CF070278DDBE530A4F1D9D9166666',
+    fill: '#6b6e90',
+    x: 100,
+    y: 200,
+    radius: 20,
+    mass: 1256,
+    velocity: {
+      angle: 0.5,
+      speed: 6,
+    },
+    vitals: {
+      calories: 1500,
+      upkeep: 48,
+      diesAt: 628,
+      spawnsAt: 2512,
+      isDead: false,
+    },
+    spikes: [
+      {
+        drain: 200,
+        fill: 'black',
+        length: 20,
+        x1: 100,
+        y1: 154,
+        x2: 102,
+        y2: 178,
+        x3: 97,
+        y3: 178,
+        offset: {
+          x1: 0,
+          y1: -46,
+          x2: 2,
+          y2: -22,
+          x3: -3,
+          y3: -22,
+        },
+        meta: { deactivateTime: null },
+      },
+    ],
+    meta: {
+      nextX: 100,
+      nextY: 200,
+      lastCollisionBody: null,
+    },
+  },
+  {
+    dna: '',
+    fill: '#792',
+    x: 200,
+    y: 100,
+    radius: 5,
+    mass: 79,
+    velocity: {
+      angle: 0.75,
+      speed: 5,
+    },
+    vitals: {
+      calories: 158,
+      upkeep: 0,
+      diesAt: 0,
+      spawnsAt: 9007199254740991,
+      isDead: false,
+    },
+    spikes: [],
+    meta: {
+      nextX: 200,
+      nextY: 100,
+      lastCollisionBody: null,
+    },
+  },
+  {
+    dna: 'F09849F244CF070278DDBE530A4F1D9D9166666F1D9D91',
+    fill: '#bb6e00',
+    x: 200,
+    y: 300,
+    radius: 10,
+    mass: 314,
+    velocity: {
+      angle: 0.25,
+      speed: 12,
+    },
+    vitals: {
+      calories: 500,
+      upkeep: 24,
+      diesAt: 157,
+      spawnsAt: 628,
+      isDead: false,
+    },
+    spikes: [
+      {
+        drain: 200,
+        fill: 'black',
+        length: 8,
+        x1: 200,
+        y1: 277,
+        x2: 202,
+        y2: 289,
+        x3: 197,
+        y3: 289,
+        offset: {
+          x1: 0,
+          y1: -23,
+          x2: 2,
+          y2: -11,
+          x3: -3,
+          y3: -11,
+        },
+        meta: { deactivateTime: null },
+      },
+      {
+        drain: 200,
+        fill: 'black',
+        length: 20,
+        x1: 200,
+        y1: 254,
+        x2: 202,
+        y2: 278,
+        x3: 197,
+        y3: 278,
+        offset: {
+          x1: 0,
+          y1: -46,
+          x2: 2,
+          y2: -22,
+          x3: -3,
+          y3: -22,
+        },
+        meta: { deactivateTime: null },
+      },
+    ],
+    meta: {
+      nextX: 200,
+      nextY: 300,
+      lastCollisionBody: null,
+    },
+  },
+  {
+    dna: '',
+    fill: '#792',
+    x: 300,
+    y: 200,
+    radius: 5,
+    mass: 79,
+    velocity: {
+      angle: 0.25,
+      speed: 15,
+    },
+    vitals: {
+      calories: 158,
+      upkeep: 0,
+      diesAt: 0,
+      spawnsAt: 9007199254740991,
+      isDead: false,
+    },
+    spikes: [],
+    meta: {
+      nextX: 300,
+      nextY: 200,
+      lastCollisionBody: null,
+    },
+  },
+  {
+    dna: '',
+    fill: '#792',
+    x: 200,
+    y: 200,
+    radius: 5,
+    mass: 79,
+    velocity: {
+      angle: 0.5,
+      speed: 25,
+    },
+    vitals: {
+      calories: 158,
+      upkeep: 0,
+      diesAt: 0,
+      spawnsAt: 9007199254740991,
+      isDead: false,
+    },
+    spikes: [],
+    meta: {
+      nextX: 200,
+      nextY: 200,
+      lastCollisionBody: null,
+    },
+  },
+];
+
+describe('Diagnostics module', () => {
+  describe('getSnapshot', () => {
+    it('should generate a report summarizing the current state of the simulation', () => {
+      expect(getSnapshot(123.45, TEST_BODIES)).to.deep.equal({
+        timestamp: 123.45,
+        meebas: 2,
+        motes: 3,
+        spikes: 3,
+        calories: 2474,
+        averageSize: 785,
+        averageSpikes: 1.5,
+        averageSpikeLength: 16,
+        averageUpkeep: 36,
+        averageSpeed: 9,
+        averageMoteSpeed: 15,
+      });
+    });
+  });
+});

--- a/tests/app/utils/diagnostics.test.js
+++ b/tests/app/utils/diagnostics.test.js
@@ -3,6 +3,7 @@
 const { expect } = require('chai');
 const {
   getSnapshot,
+  toCsv,
 } = require('./diagnostics.common.js');
 
 const TEST_BODIES = [
@@ -211,6 +212,18 @@ describe('Diagnostics module', () => {
         averageSpeed: 9,
         averageMoteSpeed: 15,
       });
+    });
+  });
+
+  describe('toCsv', () => {
+    it('should convert an array of objects into a CVS string', () => {
+      const objects = [
+        { foo: 1, bar: 2, baz: 'qux' },
+        { foo: 3, bar: 4, baz: 'quux' },
+        { foo: 5, bar: 6, baz: 'quuz' },
+      ];
+
+      expect(toCsv(objects)).to.equal('"bar","baz","foo"\n2,"qux",1\n4,"quux",3\n6,"quuz",5');
     });
   });
 });


### PR DESCRIPTION
Adds a diagnostic API which can take snapshots of the current state of the simulation and output them to CSV. Using this tool, I was able to confirm that meeba die off when offscreen is due to the rate of simulation frames, which drops down to less than one per second. This greatly reduces the chances a meeba's spikes will feed, because collision is detected by simple overlap.

With such dramatic CPU throttling by the browser, the only sensible thing to do is to pause the simulation when in the background. In the future, some sort of sweeping collision detection could be implemented, which might allow for 100ms or 1000ms frames without a significant change in selection pressure.