### PR TITLE
Add animations for feeding, death, spawning, and removal

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -28,6 +28,7 @@
                 "message": "`with` is disallowed in strict mode because it makes code impossible to predict and optimize."
             }
         ],
+        "no-unused-vars": ["error", { "argsIgnorePattern": "_+" }],
         "object-curly-newline": ["error",  { "consistent": true }],
         "spellcheck/spell-checker": ["error", {
             "skipIfMatch": [
@@ -47,6 +48,7 @@
                 "attrs",
                 "baz",
                 "bdd",
+                "booleans",
                 "calc",
                 "chai",
                 "collider",
@@ -99,6 +101,7 @@
                 "stdout",
                 "textarea",
                 "timestamp",
+                "tweener",
                 "typeof",
                 "uint",
                 "un",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -65,6 +65,7 @@
                 "drawable",
                 "drawables",
                 "extname",
+                "fader",
                 "fn",
                 "framerate",
                 "framerates",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -102,6 +102,7 @@
                 "textarea",
                 "timestamp",
                 "tweener",
+                "tweens",
                 "typeof",
                 "uint",
                 "un",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -98,6 +98,7 @@
                 "rgb",
                 "rgba",
                 "sqr",
+                "spawner",
                 "stdin",
                 "stdout",
                 "textarea",

--- a/app/meebas/bodies.js
+++ b/app/meebas/bodies.js
@@ -9,7 +9,6 @@ import {
 } from './genome.js';
 import {
   spawnSpike,
-  getSpikeMover,
 } from './spikes.js';
 import {
   initVitals,
@@ -23,9 +22,6 @@ import {
   rand,
   randInt,
 } from '../utils/math.js';
-import {
-  toVector,
-} from '../utils/physics.js';
 
 /**
  * @typedef {import('./spikes.js').Spike} Spike
@@ -163,15 +159,12 @@ export const getRandomBody = () => {
 export const replicateParent = (parent, angle) => {
   const dna = replicateGenome(toBytes(parent.dna));
   const body = initBody(dna);
-  body.vitals.calories = Math.floor(parent.vitals.calories / 2);
 
-  const relativeLocation = toVector({ angle, speed: 2 * body.radius });
-  body.x = parent.x + relativeLocation.x;
-  body.y = parent.y + relativeLocation.y;
+  body.x = parent.x;
+  body.y = parent.y;
   body.velocity.angle = angle;
   body.velocity.speed = parent.velocity.speed + randInt(0, dynamic.maxSpawningEnergy / body.mass);
-
-  body.spikes.forEach(getSpikeMover(body.x, body.y));
+  body.vitals.calories = Math.floor(parent.vitals.calories / 2);
 
   return body;
 };

--- a/app/meebas/bodies.js
+++ b/app/meebas/bodies.js
@@ -41,6 +41,10 @@ import {
  */
 
 /**
+ * @typedef {import('../utils/objects.js').Tweener} Tweener
+ */
+
+/**
  * @typedef {import('../utils/physics.js').Velocity} Velocity
  */
 

--- a/app/meebas/bodies.js
+++ b/app/meebas/bodies.js
@@ -64,6 +64,8 @@ import {
  *   @prop {number} meta.nextX - body's next horizontal location
  *   @prop {number} meta.nextY - body's next vertical location
  *   @prop {Body|null} meta.lastCollisionBody - last body collided with
+ *   @prop {boolean} meta.canInteract - able to interact with other bodies
+ *   @prop {boolean} meta.isSimulated - is a part of the simulation
  */
 
 /**
@@ -129,6 +131,8 @@ const initBody = (dna) => {
       nextX: 0,
       nextY: 0,
       lastCollisionBody: null,
+      canInteract: true,
+      isSimulated: true,
     },
   };
 };
@@ -209,6 +213,8 @@ export const spawnMote = () => {
       nextX: 0,
       nextY: 0,
       lastCollisionBody: null,
+      canInteract: true,
+      isSimulated: true,
     },
   };
 };

--- a/app/meebas/bodies.js
+++ b/app/meebas/bodies.js
@@ -13,7 +13,6 @@ import {
 } from './spikes.js';
 import {
   initVitals,
-  setCalories,
 } from './vitals.js';
 import {
   toBytes,
@@ -160,8 +159,7 @@ export const getRandomBody = () => {
 export const replicateParent = (parent, angle) => {
   const dna = replicateGenome(toBytes(parent.dna));
   const body = initBody(dna);
-
-  setCalories(body.vitals, Math.floor(parent.vitals.calories / 2));
+  body.vitals.calories = Math.floor(parent.vitals.calories / 2);
 
   const relativeLocation = toVector({ angle, speed: 2 * body.radius });
   body.x = parent.x + relativeLocation.x;

--- a/app/meebas/bodies.js
+++ b/app/meebas/bodies.js
@@ -65,7 +65,6 @@ import {
  *   @prop {number} meta.nextX - body's next horizontal location
  *   @prop {number} meta.nextY - body's next vertical location
  *   @prop {Body|null} meta.lastCollisionBody - last body collided with
- * @prop {boolean} [isInactive] - the body should be removed from the simulation
  */
 
 /**

--- a/app/meebas/spikes.js
+++ b/app/meebas/spikes.js
@@ -9,10 +9,14 @@ import {
 } from '../utils/math.js';
 
 /**
+ * @typedef {import('../utils/colors.js').HSL} HSL
+ */
+
+/**
  * A spike/triangle attached to a body/circle
  *
  * @typedef Spike
- * @prop {string} fill - this color of the spike
+ * @prop {HSL} fill - the color of the spike
  * @prop {number} length - the length of the spike
  * @prop {number} drain - how many calories drained per second
  * @prop {number} x1 - x coordinate of spike's tip
@@ -28,8 +32,6 @@ import {
  *   @prop {number} offset.y2
  *   @prop {number} offset.x3
  *   @prop {number} offset.y3
- * @prop {object} meta - simulation specific properties
- *   @prop {number|null} meta.deactivateTime
  */
 
 /**
@@ -79,7 +81,11 @@ export const spawnSpike = (radius, angle, length) => {
   const offsetAngle = asin(dynamic.halfWidth / radius);
 
   return {
-    fill: 'black',
+    fill: {
+      h: 0,
+      s: 100,
+      l: 0,
+    },
     length,
     drain: Math.ceil(dynamic.adjustedDrain / (length ** fixed.drainLengthExponent)),
     // Absolute coordinates will be set the first time the spike moves
@@ -96,9 +102,6 @@ export const spawnSpike = (radius, angle, length) => {
       y2: getYOffset(angle - offsetAngle, radius - 1),
       x3: getXOffset(angle + offsetAngle, radius - 1),
       y3: getYOffset(angle + offsetAngle, radius - 1),
-    },
-    meta: {
-      deactivateTime: null,
     },
   };
 };

--- a/app/meebas/spikes.js
+++ b/app/meebas/spikes.js
@@ -18,6 +18,7 @@ import {
  * @typedef Spike
  * @prop {HSL} fill - the color of the spike
  * @prop {number} length - the length of the spike
+ * @prop {number} angle - the angle of the spike
  * @prop {number} drain - how many calories drained per second
  * @prop {number} x1 - x coordinate of spike's tip
  * @prop {number} y1 - y coordinate of spike's tip
@@ -87,6 +88,7 @@ export const spawnSpike = (radius, angle, length) => {
       l: 0,
     },
     length,
+    angle,
     drain: Math.ceil(dynamic.adjustedDrain / (length ** fixed.drainLengthExponent)),
     // Absolute coordinates will be set the first time the spike moves
     x1: 0,

--- a/app/meebas/vitals.js
+++ b/app/meebas/vitals.js
@@ -81,19 +81,8 @@ export const initVitals = (mass, spikes) => {
 };
 
 /**
- * Explicitly set the calories on a meeba's vitals, setting isDead as needed
- *
- * @param {Vitals} vitals - the vitals to update; mutated!
- * @param {number} calories - the new calorie level
- */
-export const setCalories = (vitals, calories) => {
-  vitals.calories = calories;
-  vitals.isDead = calories < vitals.diesAt;
-};
-
-/**
- * Removes calories from the meeba, setting isDead as needed. Returns the
- * actual calories drained, which may be less than the intended amount
+ * Removes calories from the meeba, returning the actual calories drained,
+ * which may be less than the intended amount
  *
  * @param {Vitals} vitals - the vitals of the meeba to drain calories from; mutated!
  * @param {number} drain - the amount to drain
@@ -102,10 +91,6 @@ export const setCalories = (vitals, calories) => {
 export const drainCalories = (vitals, drain) => {
   const actualDrain = vitals.calories > drain ? drain : vitals.calories;
   vitals.calories -= actualDrain;
-
-  if (vitals.calories < vitals.diesAt) {
-    vitals.isDead = true;
-  }
 
   return actualDrain;
 };

--- a/app/settings.js
+++ b/app/settings.js
@@ -64,6 +64,7 @@ import {
  * @prop {number} spikeHighlightTime
  * @prop {number} averageSpikeFadeTime
  * @prop {number} averageSpikeFadeDistance
+ * @prop {number} bodyRemovalFadeTime
  */
 
 /**
@@ -169,6 +170,7 @@ export const settings = {
     spikeHighlightTime: 333,
     averageSpikeFadeTime: 1750,
     averageSpikeFadeDistance: 50,
+    bodyRemovalFadeTime: 333,
   },
   spikes: {
     baseSpikeDrain: 100000,

--- a/app/settings.js
+++ b/app/settings.js
@@ -65,6 +65,8 @@ import {
  * @prop {number} averageSpikeFadeTime
  * @prop {number} averageSpikeFadeDistance
  * @prop {number} bodyRemovalFadeTime
+ * @prop {number} bodySpawnFadeTime
+ * @prop {number} bodySpawnInactiveTime
  */
 
 /**
@@ -171,6 +173,8 @@ export const settings = {
     averageSpikeFadeTime: 1750,
     averageSpikeFadeDistance: 50,
     bodyRemovalFadeTime: 333,
+    bodySpawnFadeTime: 500,
+    bodySpawnInactiveTime: 2000,
   },
   spikes: {
     baseSpikeDrain: 100000,

--- a/app/settings.js
+++ b/app/settings.js
@@ -62,6 +62,8 @@ import {
  * @typedef SimulationModuleSettings
  * @prop {number} maxBodies
  * @prop {number} spikeHighlightTime
+ * @prop {number} averageSpikeFadeTime
+ * @prop {number} averageSpikeFadeDistance
  */
 
 /**
@@ -165,6 +167,8 @@ export const settings = {
   simulation: {
     maxBodies: 1000,
     spikeHighlightTime: 333,
+    averageSpikeFadeTime: 1750,
+    averageSpikeFadeDistance: 50,
   },
   spikes: {
     baseSpikeDrain: 100000,

--- a/app/settings.js
+++ b/app/settings.js
@@ -164,7 +164,7 @@ export const settings = {
   },
   simulation: {
     maxBodies: 1000,
-    spikeHighlightTime: 167,
+    spikeHighlightTime: 333,
   },
   spikes: {
     baseSpikeDrain: 100000,

--- a/app/simulation.js
+++ b/app/simulation.js
@@ -287,6 +287,17 @@ const getCalorieUpkeeper = (delay) => (body) => {
 };
 
 /**
+ * Checks if a body should be dead, and marks it as such if it is
+ *
+ * @param {Body} body - mutated!
+ */
+const checkDeath = ({ vitals }) => {
+  if (!vitals.isDead && vitals.calories < vitals.diesAt) {
+    vitals.isDead = true;
+  }
+};
+
+/**
  * Checks spawn status of each body, returning new meebas to add to the simulation
  *
  * @param {Body} body - the potential parent meeba

--- a/app/simulation.js
+++ b/app/simulation.js
@@ -376,8 +376,8 @@ const spawnChildren = (body) => {
  * @param {Body} body
  */
 const adjustSaturation = (body) => {
-  const { calories, diesAt, spawnsAt } = body.vitals;
-  body.fill.s = Math.floor(normalize(calories, diesAt, spawnsAt) * 100);
+  const { calories, spawnsAt } = body.vitals;
+  body.fill.s = Math.floor(normalize(calories, 0, spawnsAt) * 100);
 };
 
 /**

--- a/app/utils/colors.js
+++ b/app/utils/colors.js
@@ -46,8 +46,8 @@ export const hslToString = (hsl) => {
   const s = (l === 0 || l === 100) ? 0 : roundRange(hsl.s, 0, 100);
   const h = s === 0 ? 0 : wrapNumber(hsl.h, 360);
 
-  if (hasProp(hsl, 'a')) {
-    const a = roundRange(hsl.a, 0, 1);
+  if (hasProp(hsl, 'a') && hsl.a < 1) {
+    const a = hsl.a < 0 ? 0 : hsl.a;
     return `hsla(${h},${s}%,${l}%,${a})`;
   }
 

--- a/app/utils/objects.js
+++ b/app/utils/objects.js
@@ -1,6 +1,16 @@
 import {
   flatten,
 } from './arrays.js';
+import {
+  roundRange,
+} from './math.js';
+
+/**
+ * @callback Tweener
+ *
+ * @param {number} now - the current scaling value, for example a timestamp
+ * @returns {boolean} done - whether or not the tween has finished
+ */
 
 /**
  * Checks if a value is an object
@@ -96,4 +106,51 @@ export const listKeys = (obj, parentKeys = []) => {
 export const listValues = (obj) => {
   const keys = listKeys(obj);
   return keys.map(key => getNested(obj, key.split('.')));
+};
+
+/**
+ * Returns a function which will mutate an object's properties over time
+ *
+ * @param {Object<string, any>} target - the object to mutate
+ * @param {Object<string, any>} transform - the new properties and values
+ * @param {number} start - the starting point, for example a timestamp
+ * @param {number} duration - the length of the tween
+ * @returns {Tweener} tween - progressively applies transforms
+ */
+export const getTweener = (target, transform, start, duration) => {
+  let targetRef = /** @type {Object<string, any>|null} */ (target);
+  const transforms = Object.entries(transform);
+
+  const numbers = /** @type {{ key: string, original: number, diff: number }[]} */ (transforms
+    .filter(([_, value]) => typeof value === 'number')
+    .map(([key, final]) => {
+      const original = target[key];
+      return { key, original, diff: final - original };
+    }));
+  const others = /** @type {[string, string|boolean|null][]} */ (transforms
+    .filter(([_, value]) => typeof value !== 'number'));
+
+  return (current) => {
+    if (!targetRef) {
+      return false;
+    }
+
+    // Tween numbers
+    const delta = roundRange((current - start) / duration, 0, 1);
+    for (const { key, original, diff } of numbers) {
+      targetRef[key] = original + delta * diff;
+    }
+
+    if (delta < 1) {
+      return true;
+    }
+
+    // Tween other primitives only after delta has reached 1
+    for (const [key, value] of others) {
+      targetRef[key] = value;
+    }
+
+    targetRef = null;
+    return false;
+  };
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -78,6 +78,16 @@
         "sprintf-js": "1.0.3"
       }
     },
+    "array-includes": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
+      "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
+      "dev": true,
+      "requires": {
+        "define-properties": "1.1.3",
+        "es-abstract": "1.13.0"
+      }
+    },
     "assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
@@ -116,12 +126,6 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
-      "dev": true
-    },
-    "builtin-modules": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.0.0.tgz",
-      "integrity": "sha512-hMIeU4K2ilbXV6Uv93ZZ0Avg/M91RaKXucQ+4me2Do1txxBDyDZWCBa5bJSLqoNTRpXTLwEzIk1KmloenDDjhg==",
       "dev": true
     },
     "callsites": {
@@ -289,9 +293,9 @@
       }
     },
     "ecstatic": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/ecstatic/-/ecstatic-3.3.0.tgz",
-      "integrity": "sha512-EblWYTd+wPIAMQ0U4oYJZ7QBypT9ZUIwpqli0bKDjeIIQnXDBK2dXtZ9yzRCOlkW1HkO8gn7/FxLK1yPIW17pw==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/ecstatic/-/ecstatic-3.3.2.tgz",
+      "integrity": "sha512-fLf9l1hnwrHI2xn9mEDT7KIi22UDqA2jaCwyCbSUJh9a1V+LEUSL/JO/6TIz/QyuBURWUHrFL5Kg2TtO1bkkog==",
       "dev": true,
       "requires": {
         "he": "1.2.0",
@@ -374,12 +378,12 @@
         "esutils": "2.0.2",
         "file-entry-cache": "5.0.1",
         "functional-red-black-tree": "1.0.1",
-        "glob": "7.1.3",
+        "glob": "7.1.4",
         "globals": "11.10.0",
         "ignore": "4.0.6",
         "import-fresh": "3.0.0",
         "imurmurhash": "0.1.4",
-        "inquirer": "6.2.2",
+        "inquirer": "6.3.1",
         "js-yaml": "3.13.1",
         "json-stable-stringify-without-jsonify": "1.0.1",
         "levn": "0.3.0",
@@ -394,7 +398,7 @@
         "semver": "5.6.0",
         "strip-ansi": "4.0.0",
         "strip-json-comments": "2.0.1",
-        "table": "5.2.3",
+        "table": "5.4.0",
         "text-table": "0.2.0"
       }
     },
@@ -416,7 +420,7 @@
       "dev": true,
       "requires": {
         "debug": "2.6.9",
-        "resolve": "1.10.0"
+        "resolve": "1.11.0"
       },
       "dependencies": {
         "debug": {
@@ -437,9 +441,9 @@
       }
     },
     "eslint-module-utils": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.3.0.tgz",
-      "integrity": "sha512-lmDJgeOOjk8hObTysjqH7wyMi+nsHwwvfBykwfhjR1LNdd7C2uFJBvx4OpWYpXOw4df1yE1cDEVd1yLHitk34w==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.4.0.tgz",
+      "integrity": "sha512-14tltLm38Eu3zS+mt0KvILC3q8jyIAH518MlG+HO0p+yK885Lb1UHTY/UgR91eOyGdmxAPb+OLoW4znqIT6Ndw==",
       "dev": true,
       "requires": {
         "debug": "2.6.9",
@@ -470,21 +474,22 @@
       "dev": true
     },
     "eslint-plugin-import": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.16.0.tgz",
-      "integrity": "sha512-z6oqWlf1x5GkHIFgrSvtmudnqM6Q60KM4KvpWi5ubonMjycLjndvd5+8VAZIsTlHC03djdgJuyKG6XO577px6A==",
+      "version": "2.17.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.17.3.tgz",
+      "integrity": "sha512-qeVf/UwXFJbeyLbxuY8RgqDyEKCkqV7YC+E5S5uOjAp4tOc8zj01JP3ucoBM8JcEqd1qRasJSg6LLlisirfy0Q==",
       "dev": true,
       "requires": {
+        "array-includes": "3.0.3",
         "contains-path": "0.1.0",
         "debug": "2.6.9",
         "doctrine": "1.5.0",
         "eslint-import-resolver-node": "0.3.2",
-        "eslint-module-utils": "2.3.0",
+        "eslint-module-utils": "2.4.0",
         "has": "1.0.3",
         "lodash": "4.17.11",
         "minimatch": "3.0.4",
         "read-pkg-up": "2.0.0",
-        "resolve": "1.10.0"
+        "resolve": "1.11.0"
       },
       "dependencies": {
         "debug": {
@@ -730,9 +735,9 @@
       "dev": true
     },
     "glob": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+      "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
       "dev": true,
       "requires": {
         "fs.realpath": "1.0.0",
@@ -813,7 +818,7 @@
       "requires": {
         "colors": "1.0.3",
         "corser": "2.0.1",
-        "ecstatic": "3.3.0",
+        "ecstatic": "3.3.2",
         "http-proxy": "1.17.0",
         "opener": "1.4.3",
         "optimist": "0.6.1",
@@ -875,9 +880,9 @@
       "dev": true
     },
     "inquirer": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.2.tgz",
-      "integrity": "sha512-Z2rREiXA6cHRR9KBOarR3WuLlFzlIfAEIiB45ll5SSadMg7WqOh1MKEjjndfuH5ewXdixWCxqnVfGOQzPeiztA==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.3.1.tgz",
+      "integrity": "sha512-MmL624rfkFt4TG9y/Jvmt8vdmOo836U7Y0Hxr2aFk3RelZEGX4Igk0KabWrcaaZaTv9uzglOqWh1Vly+FAWAXA==",
       "dev": true,
       "requires": {
         "ansi-escapes": "3.2.0",
@@ -889,7 +894,7 @@
         "lodash": "4.17.11",
         "mute-stream": "0.0.7",
         "run-async": "2.3.0",
-        "rxjs": "6.4.0",
+        "rxjs": "6.5.2",
         "string-width": "2.1.1",
         "strip-ansi": "5.2.0",
         "through": "2.3.8"
@@ -917,15 +922,6 @@
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
-    },
-    "is-builtin-module": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.0.0.tgz",
-      "integrity": "sha512-/93sDihsAD652hrMEbJGbMAVBf1qc96kyThHQ0CAOONHaE3aROLpTjDe4WQ5aoC5ITHFxEq1z8XqSU7km+8amw==",
-      "dev": true,
-      "requires": {
-        "builtin-modules": "3.0.0"
-      }
     },
     "is-callable": {
       "version": "1.1.4",
@@ -1173,13 +1169,13 @@
       "dev": true
     },
     "normalize-package-data": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
-      "integrity": "sha512-ZVuHxWJv1bopjv/SD5uPhgwUhLqxdJ+SsdUQbGR9HWlXrvnd/C08Cn9Bq48PbvX3y5V97GIpAHpL5Bk9BwChGg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
       "dev": true,
       "requires": {
         "hosted-git-info": "2.7.1",
-        "is-builtin-module": "3.0.0",
+        "resolve": "1.11.0",
         "semver": "5.6.0",
         "validate-npm-package-license": "3.0.4"
       }
@@ -1437,7 +1433,7 @@
       "dev": true,
       "requires": {
         "load-json-file": "2.0.0",
-        "normalize-package-data": "2.4.1",
+        "normalize-package-data": "2.5.0",
         "path-type": "2.0.0"
       }
     },
@@ -1464,9 +1460,9 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
-      "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.0.tgz",
+      "integrity": "sha512-WL2pBDjqT6pGUNSUzMw00o4T7If+z4H2x3Gz893WoUQ5KW8Vr9txp00ykiP16VBaZF5+j/OcXJHZ9+PCvdiDKw==",
       "dev": true,
       "requires": {
         "path-parse": "1.0.6"
@@ -1494,7 +1490,7 @@
       "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
       "dev": true,
       "requires": {
-        "glob": "7.1.3"
+        "glob": "7.1.4"
       }
     },
     "run-async": {
@@ -1507,9 +1503,9 @@
       }
     },
     "rxjs": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.4.0.tgz",
-      "integrity": "sha512-Z9Yfa11F6B9Sg/BK9MnqnQ+aQYicPLtilXBp2yUtDt2JRCE0h26d33EnfO3ZxoNxG0T92OUucP3Ct7cpfkdFfw==",
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.2.tgz",
+      "integrity": "sha512-HUb7j3kvb7p7eCUHE3FqjoDsC1xfZQ4AHFWfTKSpZ+sAhhz5X1WX0ZuUqWbzB2QhSLp3DoLUG+hMdEDKqWo2Zg==",
       "dev": true,
       "requires": {
         "tslib": "1.9.3"
@@ -1566,7 +1562,7 @@
       "dev": true,
       "requires": {
         "spdx-expression-parse": "3.0.0",
-        "spdx-license-ids": "3.0.3"
+        "spdx-license-ids": "3.0.4"
       }
     },
     "spdx-exceptions": {
@@ -1582,13 +1578,13 @@
       "dev": true,
       "requires": {
         "spdx-exceptions": "2.2.0",
-        "spdx-license-ids": "3.0.3"
+        "spdx-license-ids": "3.0.4"
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.3.tgz",
-      "integrity": "sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.4.tgz",
+      "integrity": "sha512-7j8LYJLeY/Yb6ACbQ7F76qy5jHkp0U6jgBfJsk97bwWlVUnUWsAgpyaCvo17h0/RQGnQ036tVDomiwoI4pDkQA==",
       "dev": true
     },
     "sprintf-js": {
@@ -1638,9 +1634,9 @@
       }
     },
     "table": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/table/-/table-5.2.3.tgz",
-      "integrity": "sha512-N2RsDAMvDLvYwFcwbPyF3VmVSSkuF+G1e+8inhBLtHpvwXGw4QRPEZhihQNeEN0i1up6/f6ObCJXNdlRG3YVyQ==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/table/-/table-5.4.0.tgz",
+      "integrity": "sha512-nHFDrxmbrkU7JAFKqKbDJXfzrX2UBsWmrieXFTGxiI5e4ncg3VqsZeI4EzNmX0ncp4XNGVeoxIWJXfCIXwrsvw==",
       "dev": true,
       "requires": {
         "ajv": "6.10.0",
@@ -1720,9 +1716,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.2.tgz",
-      "integrity": "sha512-Og2Vn6Mk7JAuWA1hQdDQN/Ekm/SchX80VzLhjKN9ETYrIepBFAd8PkOdOTK2nKt0FCkmMZKBJvQ1dV1gIxPu/A==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.1.tgz",
+      "integrity": "sha512-64HkdiRv1yYZsSe4xC1WVgamNigVYjlssIoaH2HcZF0+ijsk5YK2g0G34w9wJkze8+5ow4STd22AynfO6ZYYLw==",
       "dev": true
     },
     "union": {

--- a/package.json
+++ b/package.json
@@ -27,10 +27,10 @@
     "eslint": "^5.16.0",
     "eslint-config-airbnb-base": "^13.1.0",
     "eslint-plugin-curry": "^0.1.0",
-    "eslint-plugin-import": "^2.16.0",
+    "eslint-plugin-import": "^2.17.3",
     "eslint-plugin-spellcheck": "0.0.11",
     "http-server": "^0.11.1",
     "mocha": "^5.2.0",
-    "typescript": "^3.4.2"
+    "typescript": "^3.5.1"
   }
 }

--- a/tests/app/meebas/spikes.test.js
+++ b/tests/app/meebas/spikes.test.js
@@ -23,7 +23,10 @@ describe('Spike methods', () => {
       const spike = spawnSpike(91, 0.875, 50);
 
       expect(spike.length).to.equal(50);
-      expect(spike.fill).to.be.a('string');
+      expect(spike.fill).to.be.an('object');
+      expect(spike.fill.h).to.be.within(0, 360);
+      expect(spike.fill.s).to.be.within(0, 100);
+      expect(spike.fill.l).to.be.within(0, 100);
 
       expect(spike.x1).to.be.a('number');
       expect(spike.y1).to.be.a('number');

--- a/tests/app/meebas/vitals.test.js
+++ b/tests/app/meebas/vitals.test.js
@@ -4,7 +4,6 @@ const { expect } = require('chai');
 const { spawnSpike } = require('./spikes.common.js');
 const {
   initVitals,
-  setCalories,
   drainCalories,
 } = require('./vitals.common.js');
 
@@ -28,23 +27,6 @@ describe('Vitals methods', () => {
     });
   });
 
-  describe('setCalories', () => {
-    it('should mutate a vitals object with a specific calorie level', () => {
-      const vitals = initVitals(100, []);
-      setCalories(vitals, 50);
-
-      expect(vitals.calories).to.equal(50);
-    });
-
-    it('should update isDead as needed', () => {
-      const vitals = initVitals(100, []);
-      vitals.isDead = 50;
-      setCalories(vitals, 49);
-
-      expect(vitals.isDead).to.equal(true);
-    });
-  });
-
   describe('drainCalories', () => {
     it('should drain calories from a vitals object', () => {
       const vitals = { calories: 100, diesAt: 50, isDead: false };
@@ -58,13 +40,6 @@ describe('Vitals methods', () => {
       const actualDrain = drainCalories(vitals, 200);
 
       expect(actualDrain).to.equal(100);
-    });
-
-    it('should mark vitals as dead if calories drops below threshold', () => {
-      const vitals = { calories: 100, diesAt: 50, isDead: false };
-      drainCalories(vitals, 75);
-
-      expect(vitals.isDead).to.equal(true);
     });
   });
 });

--- a/tests/app/utils/colors.test.js
+++ b/tests/app/utils/colors.test.js
@@ -16,6 +16,10 @@ describe('Color utils', () => {
       expect(hslToString({ h: 153, s: 0, l: 87 })).to.equal('hsl(0,0%,87%)');
     });
 
+    it('should drop explicit alpha when set to 1', () => {
+      expect(hslToString({ h: 120, s: 100, l: 50, a: 1 })).to.equal('hsl(120,100%,50%)');
+    });
+
     it('should drop hue and saturation when fully lightened or darkened', () => {
       expect(hslToString({ h: 217, s: 72, l: 0 })).to.equal('hsl(0,0%,0%)');
       expect(hslToString({ h: 2, s: 2, l: 100 })).to.equal('hsl(0,0%,100%)');
@@ -45,7 +49,7 @@ describe('Color utils', () => {
     });
 
     it('should round alphas over 1 down to 1', () => {
-      expect(hslToString({ h: 90, s: 25, l: 75, a: 17 })).to.equal('hsla(90,25%,75%,1)');
+      expect(hslToString({ h: 90, s: 25, l: 75, a: 17 })).to.equal('hsl(90,25%,75%)');
     });
   });
 

--- a/tests/app/utils/objects.test.js
+++ b/tests/app/utils/objects.test.js
@@ -9,6 +9,7 @@ const {
   setNested,
   listKeys,
   listValues,
+  getTweener,
 } = require('./objects.common.js');
 
 describe('Object utils', () => {
@@ -204,6 +205,98 @@ describe('Object utils', () => {
       });
 
       expect(keys).to.deep.equal([{}, undefined, 7]);
+    });
+  });
+
+  describe('getTweener', () => {
+    it('should take an object, a transform, a start, a duration, and return a function', () => {
+      const target = { foo: 1, bar: 2 };
+      expect(getTweener(target, { foo: 5 }, 1000, 100)).to.be.a('function');
+    });
+
+    it('should mutate the target object with the returned tween function', () => {
+      const target = { foo: 1, bar: 2 };
+      const tween = getTweener(target, { foo: 5 }, 1000, 100);
+
+      tween(1100);
+      expect(target.foo).to.equal(5);
+    });
+
+    it('should apply partial transforms to numbers', () => {
+      const target = { foo: 1, bar: 2 };
+      const tween = getTweener(target, { foo: 5 }, 1000, 100);
+
+      tween(1050);
+      expect(target.foo).to.equal(3);
+    });
+
+    it('should accept multiple transform properties', () => {
+      const target = { foo: 1, bar: 2 };
+      const tween = getTweener(target, { foo: 5, bar: -8 }, 1000, 100);
+
+      tween(1050);
+      expect(target.foo).to.equal(3);
+      expect(target.bar).to.equal(-3);
+    });
+
+    it('should transform multiple times until the duration is complete', () => {
+      const target = { foo: 1, bar: 2 };
+      const tween = getTweener(target, { foo: 5 }, 1000, 100);
+
+      tween(1025);
+      expect(target.foo).to.equal(2);
+
+      tween(1050);
+      expect(target.foo).to.equal(3);
+
+      tween(1075);
+      expect(target.foo).to.equal(4);
+
+      tween(1100);
+      expect(target.foo).to.equal(5);
+    });
+
+    it('should modify booleans, strings, and null only once the duration has elapsed', () => {
+      const target = { foo: true, bar: 'qux', baz: 72 };
+      const tween = getTweener(target, { foo: false, bar: 'quux', baz: null }, 1000, 100);
+
+      tween(1050);
+      expect(target.foo).to.equal(true);
+      expect(target.bar).to.equal('qux');
+      expect(target.baz).to.equal(72);
+
+      tween(1100);
+      expect(target.foo).to.equal(false);
+      expect(target.bar).to.equal('quux');
+      expect(target.baz).to.equal(null);
+    });
+
+    it('should not apply further transforms after reaching the duration', () => {
+      const target = { foo: 1, bar: 2 };
+      const tween = getTweener(target, { foo: 5 }, 1000, 100);
+
+      tween(1500);
+      expect(target.foo).to.equal(5);
+
+      tween(2000);
+      expect(target.foo).to.equal(5);
+
+      tween(1050);
+      expect(target.foo).to.equal(5);
+    });
+
+    it('should return true if there is more transforming left to do', () => {
+      const target = { foo: 1, bar: 2 };
+      const tween = getTweener(target, { foo: 5 }, 1000, 100);
+
+      expect(tween(1050)).to.equal(true);
+    });
+
+    it('should return false if the transform is complete', () => {
+      const target = { foo: 1, bar: 2 };
+      const tween = getTweener(target, { foo: 5 }, 1000, 100);
+
+      expect(tween(1100)).to.equal(false);
     });
   });
 });


### PR DESCRIPTION
Creates a new tweening utility which can be used to create tween functions which mutate object properties over time. The simulation runs these tweens on each frame, discarding them when the tween is complete. This is used to create a number of "animations", as well as to make some simulation effects happen over time.

- Spikes turn red at the moment of feeding, and then fade back to black over time
- Bodies fade out before being removed from the simulation
- Spawned children fade in over time
- Spikes fall off and fade out on meeba death