### PR TITLE
Improve collision detection by snapping overlapping bodies to edge

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -10,7 +10,6 @@ import {
   restoreDefaultSettings,
 } from './settings.js';
 import {
-  separateBodies,
   simulateFrame,
 } from './simulation.js';
 import {
@@ -126,7 +125,6 @@ MeebaFarm.reset = () => {
   console.log('Starting simulation with seed:', core.seed);
   seedPrng(core.seed);
   MeebaFarm.bodies = range(core.startingMeebaCount).map(getRandomBody);
-  separateBodies(MeebaFarm.bodies);
 };
 
 MeebaFarm.snapshots = {

--- a/app/meebas/bodies.js
+++ b/app/meebas/bodies.js
@@ -57,8 +57,6 @@ import {
  * @prop {Vitals} vitals - life-cycle properties of the body
  * @prop {Spike[]} spikes - the spikes of the meeba
  * @prop {object} meta - extra properties specific to the simulation
- *   @prop {number} meta.nextX - body's next horizontal location
- *   @prop {number} meta.nextY - body's next vertical location
  *   @prop {Body|null} meta.lastCollisionBody - last body collided with
  *   @prop {boolean} meta.canInteract - able to interact with other bodies
  *   @prop {boolean} meta.isSimulated - is a part of the simulation
@@ -124,8 +122,6 @@ const initBody = (dna) => {
     vitals: initVitals(mass, spikes),
     spikes,
     meta: {
-      nextX: 0,
-      nextY: 0,
       lastCollisionBody: null,
       canInteract: true,
       isSimulated: true,
@@ -203,8 +199,6 @@ export const spawnMote = () => {
     },
     spikes: [],
     meta: {
-      nextX: 0,
-      nextY: 0,
       lastCollisionBody: null,
       canInteract: true,
       isSimulated: true,

--- a/app/meebas/bodies.js
+++ b/app/meebas/bodies.js
@@ -57,7 +57,6 @@ import {
  * @prop {Vitals} vitals - life-cycle properties of the body
  * @prop {Spike[]} spikes - the spikes of the meeba
  * @prop {object} meta - extra properties specific to the simulation
- *   @prop {Body|null} meta.lastCollisionBody - last body collided with
  *   @prop {boolean} meta.canInteract - able to interact with other bodies
  *   @prop {boolean} meta.isSimulated - is a part of the simulation
  */
@@ -122,7 +121,6 @@ const initBody = (dna) => {
     vitals: initVitals(mass, spikes),
     spikes,
     meta: {
-      lastCollisionBody: null,
       canInteract: true,
       isSimulated: true,
     },
@@ -199,7 +197,6 @@ export const spawnMote = () => {
     },
     spikes: [],
     meta: {
-      lastCollisionBody: null,
       canInteract: true,
       isSimulated: true,
     },

--- a/app/simulation.js
+++ b/app/simulation.js
@@ -68,6 +68,7 @@ import {
  */
 
 const MAX_TIME_PER_FRAME = 0.1;
+const SNAP_GAP = 0.1;
 
 const { core, bodies: bodySettings, simulation: fixed } = settings;
 const dynamic = /** @type {DynamicSimulationSettings} */ ({});
@@ -105,7 +106,7 @@ const getBodyMover = (delay) => (body) => {
  * @param {Body} body - mutated!
  */
 const bounceWallIfPast = (body) => {
-  const { x, y, radius, velocity: { angle }, meta } = body;
+  const { x, y, radius, velocity: { angle } } = body;
 
   if (getGap(0, angle) < 0.25 && x > core.width - radius) {
     bounceX(body);
@@ -115,11 +116,7 @@ const bounceWallIfPast = (body) => {
     bounceX(body);
   } else if (getGap(0.75, angle) < 0.25 && y > core.height - radius) {
     bounceY(body);
-  } else {
-    return;
   }
-
-  meta.lastCollisionBody = null;
 };
 
 /**
@@ -192,20 +189,15 @@ const getSpikeOverlapChecker = (body, other) => (spike) => {
  * @param {Body} body2 - mutated!
  */
 const collideIfOverlapping = (body1, body2) => {
-  const justCollided = body1.meta.lastCollisionBody === body2
-    && body2.meta.lastCollisionBody === body1;
-
-  if (!justCollided && bodiesDoOverlap(body1, body2)) {
+  if (bodiesDoOverlap(body1, body2)) {
     // Move smaller body outside larger body
     if (body1.radius > body2.radius) {
-      snapCircleToEdge(body1, body2);
+      snapCircleToEdge(body1, body2, SNAP_GAP);
     } else {
-      snapCircleToEdge(body2, body1);
+      snapCircleToEdge(body2, body1, SNAP_GAP);
     }
 
     collide(body1, body2);
-    body1.meta.lastCollisionBody = body2;
-    body2.meta.lastCollisionBody = body1;
   }
 };
 

--- a/app/simulation.js
+++ b/app/simulation.js
@@ -17,10 +17,12 @@ import {
   flatten,
 } from './utils/arrays.js';
 import {
-  getGap,
   isShorter,
   isCloser,
+} from './utils/geometry.js';
+import {
   normalize,
+  getGap,
   rand,
   randInt,
 } from './utils/math.js';

--- a/app/utils/geometry.js
+++ b/app/utils/geometry.js
@@ -79,19 +79,22 @@ export const isCloser = ({ x, y }, { x1, y1, x2, y2 }, distance) => {
 };
 
 /**
- * Moves a second circle so it touches the edge of a target circle
+ * Moves a second circle so it touches the edge of a target circle,
+ * optionally leaving a gap between
  *
  * @param {Circle} target - base circle, unmoved
  * @param {Circle} other - moved circle, mutated!
+ * @param {number} [gap] - number of pixels to leave between, defaults to 0
+ *
  */
-export const snapCircleToEdge = ({ x, y, radius }, other) => {
+export const snapCircleToEdge = ({ x, y, radius }, other, gap = 0) => {
   const { angle } = toVelocity({
     x: x - other.x,
     y: y - other.y,
   });
   const separation = toVector({
     angle,
-    speed: radius + other.radius,
+    speed: radius + other.radius + gap,
   });
 
   other.x = x - separation.x;

--- a/app/utils/geometry.js
+++ b/app/utils/geometry.js
@@ -1,0 +1,69 @@
+import { sqr, dotProduct } from './math.js';
+
+/**
+ * A point defined by an x/y coordinate
+ *
+ * @typedef Point
+ * @prop {number} x
+ * @prop {number} y
+ */
+
+/**
+ * A line segment defined by a pair of x/y coordinates
+ *
+ * @typedef Line
+ * @prop {number} x1
+ * @prop {number} y1
+ * @prop {number} x2
+ * @prop {number} y2
+ */
+
+/**
+ * Efficiently checks if a line is shorter than a distance (no sqrt)
+ *
+ * @param {Line} line
+ * @param {number} distance
+ * @returns {boolean}
+ */
+export const isShorter = ({ x1, y1, x2, y2 }, distance) => (
+  sqr(x1 - x2) + sqr(y1 - y2) < sqr(distance)
+);
+
+/**
+ * Checks if a point is closer to a line segment than a certain distance (no sqrt),
+ * adapted from this StackOverflow answer: https://stackoverflow.com/a/6853926/4284401
+ *
+ * @param {Point} point
+ * @param {Line} line
+ * @param {number} distance
+ * @returns {boolean}
+ */
+export const isCloser = ({ x, y }, { x1, y1, x2, y2 }, distance) => {
+  const xLength = x2 - x1;
+  const yLength = y2 - y1;
+
+  const lengthSquared = dotProduct([xLength, yLength], [xLength, yLength]);
+  const projection = lengthSquared > 0
+    ? dotProduct([x - x1, y - y1], [xLength, yLength]) / lengthSquared
+    : -1;
+
+  let closestX;
+  let closestY;
+  if (projection < 0) {
+    closestX = x1;
+    closestY = y1;
+  } else if (projection > 1) {
+    closestX = x2;
+    closestY = y2;
+  } else {
+    closestX = x1 + projection * xLength;
+    closestY = y1 + projection * yLength;
+  }
+
+  return isShorter({
+    x1: x,
+    y1: y,
+    x2: closestX,
+    y2: closestY,
+  }, distance);
+};

--- a/app/utils/geometry.js
+++ b/app/utils/geometry.js
@@ -1,4 +1,5 @@
 import { sqr, dotProduct } from './math.js';
+import { toVector, toVelocity } from './physics.js';
 
 /**
  * A point defined by an x/y coordinate
@@ -16,6 +17,15 @@ import { sqr, dotProduct } from './math.js';
  * @prop {number} y1
  * @prop {number} x2
  * @prop {number} y2
+ */
+
+/**
+ * A circle defined by an x/y center point and a radius
+ *
+ * @typedef Circle
+ * @prop {number} x
+ * @prop {number} y
+ * @prop {number} radius
  */
 
 /**
@@ -66,4 +76,24 @@ export const isCloser = ({ x, y }, { x1, y1, x2, y2 }, distance) => {
     x2: closestX,
     y2: closestY,
   }, distance);
+};
+
+/**
+ * Moves a second circle so it touches the edge of a target circle
+ *
+ * @param {Circle} target - base circle, unmoved
+ * @param {Circle} other - moved circle, mutated!
+ */
+export const snapCircleToEdge = ({ x, y, radius }, other) => {
+  const { angle } = toVelocity({
+    x: x - other.x,
+    y: y - other.y,
+  });
+  const separation = toVector({
+    angle,
+    speed: radius + other.radius,
+  });
+
+  other.x = x - separation.x;
+  other.y = y - separation.y;
 };

--- a/app/utils/math.js
+++ b/app/utils/math.js
@@ -13,24 +13,6 @@ const LOOKUP_TABLES = {
 };
 
 /**
- * A point defined by an x/y coordinate
- *
- * @typedef Point
- * @prop {number} x
- * @prop {number} y
- */
-
-/**
- * A line segment defined by a pair of x/y coordinates
- *
- * @typedef Line
- * @prop {number} x1
- * @prop {number} y1
- * @prop {number} x2
- * @prop {number} y2
- */
-
-/**
  * Convenience function to square a number
  *
  * @param {number} n
@@ -48,24 +30,6 @@ export const sqr = n => n * n;
 export const dotProduct = (set1, set2) => set1
   .map((n1, i) => n1 * set2[i])
   .reduce((sum, n) => sum + n);
-
-/**
- * Normalize an angle in turns, rounding it to be between 0 and 1
- *
- * 1 turn = 360°, 2π, one full rotation; 1.5 turns = 180°, 1π, 0.5 turns
- *
- * @param {number} turns - a floating point count of rotations
- * @returns {number} - the same angle normalized between 0 and 1
- */
-export const roundAngle = (turns) => {
-  if (turns >= 1) {
-    return turns % 1;
-  }
-  if (turns < 0) {
-    return turns + Math.ceil(Math.abs(turns));
-  }
-  return turns;
-};
 
 /**
  * Rounds a number to be no less or more than a min and max
@@ -96,6 +60,37 @@ export const roundRange = (num, min, max) => {
  * @returns {number} - percentage from 0.0 to 1.0
  */
 export const normalize = (num, min, max) => (roundRange(num, min, max) - min) / (max - min);
+
+
+/**
+ * Normalize an angle in turns, rounding it to be between 0 and 1
+ *
+ * 1 turn = 360°, 2π, one full rotation; 1.5 turns = 180°, 1π, 0.5 turns
+ *
+ * @param {number} turns - a floating point count of rotations
+ * @returns {number} - the same angle normalized between 0 and 1
+ */
+export const roundAngle = (turns) => {
+  if (turns >= 1) {
+    return turns % 1;
+  }
+  if (turns < 0) {
+    return turns + Math.ceil(Math.abs(turns));
+  }
+  return turns;
+};
+
+/**
+ * Returns the size of the gap between two angles in turns
+ *
+ * @param {number} angle1
+ * @param {number} angle2
+ * @returns {number} - the difference between the two angles
+ */
+export const getGap = (angle1, angle2) => {
+  const gap = Math.abs(roundAngle(angle1) - roundAngle(angle2));
+  return gap <= 0.5 ? gap : 1 - gap;
+};
 
 /**
  * Creates a trig function based on a lookup table, accepting an angle in "turns"
@@ -148,68 +143,6 @@ export const asin = getInverseTrigFn(LOOKUP_TABLES.ASIN);
  * @returns {number} - angle in turns
  */
 export const acos = getInverseTrigFn(LOOKUP_TABLES.ACOS);
-
-/**
- * Efficiently checks if a line is shorter than a distance (no sqrt)
- *
- * @param {Line} line
- * @param {number} distance
- * @returns {boolean}
- */
-export const isShorter = ({ x1, y1, x2, y2 }, distance) => (
-  sqr(x1 - x2) + sqr(y1 - y2) < sqr(distance)
-);
-
-/**
- * Checks if a point is closer to a line segment than a certain distance (no sqrt),
- * adapted from this StackOverflow answer: https://stackoverflow.com/a/6853926/4284401
- *
- * @param {Point} point
- * @param {Line} line
- * @param {number} distance
- * @returns {boolean}
- */
-export const isCloser = ({ x, y }, { x1, y1, x2, y2 }, distance) => {
-  const xLength = x2 - x1;
-  const yLength = y2 - y1;
-
-  const lengthSquared = dotProduct([xLength, yLength], [xLength, yLength]);
-  const projection = lengthSquared > 0
-    ? dotProduct([x - x1, y - y1], [xLength, yLength]) / lengthSquared
-    : -1;
-
-  let closestX;
-  let closestY;
-  if (projection < 0) {
-    closestX = x1;
-    closestY = y1;
-  } else if (projection > 1) {
-    closestX = x2;
-    closestY = y2;
-  } else {
-    closestX = x1 + projection * xLength;
-    closestY = y1 + projection * yLength;
-  }
-
-  return isShorter({
-    x1: x,
-    y1: y,
-    x2: closestX,
-    y2: closestY,
-  }, distance);
-};
-
-/**
- * Returns the size of the gap between two angles in turns
- *
- * @param {number} angle1
- * @param {number} angle2
- * @returns {number} - the difference between the two angles
- */
-export const getGap = (angle1, angle2) => {
-  const gap = Math.abs(roundAngle(angle1) - roundAngle(angle2));
-  return gap <= 0.5 ? gap : 1 - gap;
-};
 
 /**
  * A simple pseudo-random number generator which takes a base36 seed

--- a/tests/app/meebas/bodies.test.js
+++ b/tests/app/meebas/bodies.test.js
@@ -33,6 +33,8 @@ const expectIsValidNewBody = (body) => {
 
   expect(body.spikes).to.be.an('array');
   expect(body.meta.lastCollisionBody).to.equal(null);
+  expect(body.meta.canInteract).to.be.true;
+  expect(body.meta.isSimulated).to.be.true;
 };
 
 describe('Body methods', () => {

--- a/tests/app/meebas/bodies.test.js
+++ b/tests/app/meebas/bodies.test.js
@@ -32,8 +32,6 @@ const expectIsValidNewBody = (body) => {
   expect(body.velocity.speed).to.be.a('number');
 
   expect(body.spikes).to.be.an('array');
-  expect(body.meta.nextX).to.be.a('number');
-  expect(body.meta.nextY).to.be.a('number');
   expect(body.meta.lastCollisionBody).to.equal(null);
 };
 

--- a/tests/app/meebas/bodies.test.js
+++ b/tests/app/meebas/bodies.test.js
@@ -32,7 +32,6 @@ const expectIsValidNewBody = (body) => {
   expect(body.velocity.speed).to.be.a('number');
 
   expect(body.spikes).to.be.an('array');
-  expect(body.meta.lastCollisionBody).to.equal(null);
   expect(body.meta.canInteract).to.be.true;
   expect(body.meta.isSimulated).to.be.true;
 };

--- a/tests/app/simulation.test.js
+++ b/tests/app/simulation.test.js
@@ -9,11 +9,9 @@ const {
   getRandomBody,
 } = require('./meebas/bodies.common.js');
 const {
-  separateBodies,
   simulateFrame,
 } = require('./simulation.common.js');
 
-const sqr = n => n * n;
 const getCircleArea = radius => Math.floor(Math.PI * radius * radius);
 
 describe('Simulation methods', () => {
@@ -33,40 +31,23 @@ describe('Simulation methods', () => {
     updateSetting('moteSpawnRate', oldRate);
   });
 
-  describe('separateBodies', () => {
-    it('should separate overlapping bodies', () => {
-      const body1 = { ...getRandomBody(), x: 45, y: 50, radius: 10 };
-      const body2 = { ...getRandomBody(), x: 55, y: 50, radius: 10 };
-
-      separateBodies([body1, body2]);
-
-      const separation = Math.sqrt(sqr(body1.x - body2.x) + sqr(body1.y - body2.y));
-      expect(separation).to.be.at.least(20);
-    });
-
-    it('should fail gracefully if no solution is possible', () => {
-      const body1 = { x: 50, y: 50, radius: 1000 };
-      const body2 = { x: 50, y: 50, radius: 1000 };
-
-      expect(() => separateBodies([body1, body2])).to.not.throw();
-    });
-  });
-
   describe('simulateFrame', () => {
     it('should simulate movement over time', () => {
-      const body = {
-        ...getRandomBody(),
-        radius: 10,
-        mass: getCircleArea(10),
-        x: 50,
-        y: 50,
-        velocity: {
-          angle: 0,
-          speed: 100,
+      let bodies = [
+        {
+          ...getRandomBody(),
+          radius: 10,
+          mass: getCircleArea(10),
+          x: 50,
+          y: 50,
+          velocity: {
+            angle: 0,
+            speed: 100,
+          },
         },
-      };
+      ];
 
-      let bodies = simulateFrame([body], 0, 100);
+      bodies = simulateFrame(bodies, 0, 100);
       expect(bodies[0].x).to.equal(60);
       expect(bodies[0].y).to.equal(50);
 
@@ -77,50 +58,55 @@ describe('Simulation methods', () => {
     });
 
     it('should simulate wall bounces', () => {
-      const body = {
-        ...getRandomBody(),
-        radius: 10,
-        mass: getCircleArea(10),
-        x: 15,
-        y: 50,
-        velocity: {
-          angle: 0.5,
-          speed: 100,
+      let bodies = [
+        {
+          ...getRandomBody(),
+          radius: 10,
+          mass: getCircleArea(10),
+          x: 15,
+          y: 50,
+          velocity: {
+            angle: 0.5,
+            speed: 100,
+          },
         },
-      };
+      ];
 
-      const bodies = simulateFrame([body], 0, 100);
+      bodies = simulateFrame(bodies, 0, 100);
+      bodies = simulateFrame(bodies, 0, 101);
 
       expect(bodies[0].velocity.angle).to.equal(0);
       expect(bodies[0].velocity.speed).to.equal(100);
     });
 
     it('should simulate body collisions', () => {
-      const body1 = {
-        ...getRandomBody(),
-        radius: 10,
-        mass: getCircleArea(10),
-        x: 35,
-        y: 50,
-        velocity: {
-          angle: 0,
-          speed: 100,
+      let bodies = [
+        {
+          ...getRandomBody(),
+          radius: 10,
+          mass: getCircleArea(10),
+          x: 35,
+          y: 50,
+          velocity: {
+            angle: 0,
+            speed: 100,
+          },
         },
-      };
-
-      const body2 = {
-        ...getRandomBody(),
-        radius: 10,
-        mass: getCircleArea(10),
-        x: 65,
-        y: 50,
-        velocity: {
-          angle: 0.5,
-          speed: 100,
+        {
+          ...getRandomBody(),
+          radius: 10,
+          mass: getCircleArea(10),
+          x: 65,
+          y: 50,
+          velocity: {
+            angle: 0.5,
+            speed: 100,
+          },
         },
-      };
+      ];
 
-      const bodies = simulateFrame([body1, body2], 0, 100);
+      bodies = simulateFrame(bodies, 0, 100);
+      bodies = simulateFrame(bodies, 0, 101);
 
       expect(bodies[0].velocity.angle).to.equal(0.5);
       expect(bodies[0].velocity.speed).to.equal(100);
@@ -130,19 +116,21 @@ describe('Simulation methods', () => {
     });
 
     it('should throttle frames to be no longer than 100ms', () => {
-      const body = {
-        ...getRandomBody(),
-        radius: 10,
-        mass: getCircleArea(10),
-        x: 50,
-        y: 50,
-        velocity: {
-          angle: 0,
-          speed: 100,
+      let bodies = [
+        {
+          ...getRandomBody(),
+          radius: 10,
+          mass: getCircleArea(10),
+          x: 50,
+          y: 50,
+          velocity: {
+            angle: 0,
+            speed: 100,
+          },
         },
-      };
+      ];
 
-      const bodies = simulateFrame([body], 0, 1000);
+      bodies = simulateFrame(bodies, 0, 1000);
       expect(bodies[0].x).to.equal(60);
       expect(bodies[0].y).to.equal(50);
     });

--- a/tests/app/utils/geometry.test.js
+++ b/tests/app/utils/geometry.test.js
@@ -4,6 +4,7 @@ const { expect } = require('chai');
 const {
   isShorter,
   isCloser,
+  snapCircleToEdge,
 } = require('./geometry.common.js');
 
 describe('Geometry utils', () => {
@@ -49,6 +50,42 @@ describe('Geometry utils', () => {
     it('should compare the shortest distance when the line has a length of zero', () => {
       expect(isCloser({ x: 95, y: 95 }, { x1: 100, y1: 100, x2: 100, y2: 100 }, 7.08)).to.be.true;
       expect(isCloser({ x: 95, y: 95 }, { x1: 100, y1: 100, x2: 100, y2: 100 }, 7.06)).to.be.false;
+    });
+  });
+
+  describe('snapCircleToEdge', () => {
+    it('should move a circle that overlaps with target circle', () => {
+      const target = { x: 10, y: 10, radius: 8 };
+      const other = { x: 10, y: 20, radius: 5 };
+
+      snapCircleToEdge(target, other);
+
+      expect(target).to.deep.equal({ x: 10, y: 10, radius: 8 });
+      expect(other).to.deep.equal({ x: 10, y: 23, radius: 5 });
+    });
+
+    it('should move a circle which does not overlap', () => {
+      const target = { x: 10, y: 10, radius: 8 };
+      const other = { x: 10, y: 50, radius: 5 };
+
+      snapCircleToEdge(target, other);
+
+      expect(target).to.deep.equal({ x: 10, y: 10, radius: 8 });
+      expect(other).to.deep.equal({ x: 10, y: 23, radius: 5 });
+    });
+
+    it('should handle overlaps on diagonals', () => {
+      const target = { x: 31.4, y: 42, radius: 13 };
+      const other = { x: 36.7, y: 39, radius: 7.2 };
+
+      snapCircleToEdge(target, other);
+
+      expect(target).to.deep.equal({ x: 31.4, y: 42, radius: 13 });
+      expect(other).to.deep.equal({
+        x: 49.03651856404946,
+        y: 32.1514867650016,
+        radius: 7.2,
+      });
     });
   });
 });

--- a/tests/app/utils/geometry.test.js
+++ b/tests/app/utils/geometry.test.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const { expect } = require('chai');
+const {
+  isShorter,
+  isCloser,
+} = require('./geometry.common.js');
+
+describe('Geometry utils', () => {
+  describe('isShorter', () => {
+    it('should compare the length of line segment to a set distance', () => {
+      expect(isShorter({ x1: 0, y1: 0, x2: 3, y2: 0 }, 4)).to.be.true;
+      expect(isShorter({ x1: 0, y1: 0, x2: 3, y2: 0 }, 2)).to.be.false;
+
+      expect(isShorter({ x1: 10, y1: 10, x2: 10, y2: 20 }, 11)).to.be.true;
+      expect(isShorter({ x1: 10, y1: 10, x2: 10, y2: 20 }, 9)).to.be.false;
+
+      expect(isShorter({ x1: 1, y1: 1, x2: 2, y2: 2 }, 1.415)).to.be.true;
+      expect(isShorter({ x1: 1, y1: 1, x2: 2, y2: 2 }, 1.413)).to.be.false;
+
+      expect(isShorter({ x1: 120, y1: 83, x2: 572, y2: 313 }, 508)).to.be.true;
+      expect(isShorter({ x1: 120, y1: 83, x2: 572, y2: 313 }, 506)).to.be.false;
+    });
+  });
+
+  describe('isCloser', () => {
+    it('should compare the shortest distance between a point a line to a set distance', () => {
+      expect(isCloser({ x: 2, y: 3 }, { x1: 0, y1: 0, x2: 4, y2: 0 }, 4)).to.be.true;
+      expect(isCloser({ x: 2, y: 3 }, { x1: 0, y1: 0, x2: 4, y2: 0 }, 2)).to.be.false;
+
+      expect(isCloser({ x: 20, y: 15 }, { x1: 10, y1: 10, x2: 10, y2: 20 }, 11)).to.be.true;
+      expect(isCloser({ x: 20, y: 15 }, { x1: 10, y1: 10, x2: 10, y2: 20 }, 9)).to.be.false;
+
+      expect(isCloser({ x: 2, y: 1 }, { x1: 1, y1: 1, x2: 2, y2: 2 }, 0.708)).to.be.true;
+      expect(isCloser({ x: 2, y: 1 }, { x1: 1, y1: 1, x2: 2, y2: 2 }, 0.706)).to.be.false;
+    });
+
+    it('should compare the shortest distance when the point is beyond the line', () => {
+      expect(isCloser({ x: 7, y: 0 }, { x1: 0, y1: 0, x2: 4, y2: 0 }, 4)).to.be.true;
+      expect(isCloser({ x: 7, y: 0 }, { x1: 0, y1: 0, x2: 4, y2: 0 }, 2)).to.be.false;
+
+      expect(isCloser({ x: 10, y: 0 }, { x1: 10, y1: 10, x2: 10, y2: 20 }, 11)).to.be.true;
+      expect(isCloser({ x: 10, y: 0 }, { x1: 10, y1: 10, x2: 10, y2: 20 }, 9)).to.be.false;
+
+      expect(isCloser({ x: 3, y: 3 }, { x1: 1, y1: 1, x2: 2, y2: 2 }, 1.415)).to.be.true;
+      expect(isCloser({ x: 3, y: 3 }, { x1: 1, y1: 1, x2: 2, y2: 2 }, 1.414)).to.be.false;
+    });
+
+    it('should compare the shortest distance when the line has a length of zero', () => {
+      expect(isCloser({ x: 95, y: 95 }, { x1: 100, y1: 100, x2: 100, y2: 100 }, 7.08)).to.be.true;
+      expect(isCloser({ x: 95, y: 95 }, { x1: 100, y1: 100, x2: 100, y2: 100 }, 7.06)).to.be.false;
+    });
+  });
+});

--- a/tests/app/utils/geometry.test.js
+++ b/tests/app/utils/geometry.test.js
@@ -64,6 +64,16 @@ describe('Geometry utils', () => {
       expect(other).to.deep.equal({ x: 10, y: 23, radius: 5 });
     });
 
+    it('should optionally leave a gap between the circles', () => {
+      const target = { x: 10, y: 10, radius: 8 };
+      const other = { x: 10, y: 20, radius: 5 };
+
+      snapCircleToEdge(target, other, 1);
+
+      expect(target).to.deep.equal({ x: 10, y: 10, radius: 8 });
+      expect(other).to.deep.equal({ x: 10, y: 24, radius: 5 });
+    });
+
     it('should move a circle which does not overlap', () => {
       const target = { x: 10, y: 10, radius: 8 };
       const other = { x: 10, y: 50, radius: 5 };

--- a/tests/app/utils/math.test.js
+++ b/tests/app/utils/math.test.js
@@ -9,13 +9,11 @@ const {
   roundRange,
   normalize,
   roundAngle,
+  getGap,
   sin,
   cos,
   asin,
   acos,
-  isShorter,
-  isCloser,
-  getGap,
   seedPrng,
   rand,
   randInt,
@@ -28,6 +26,17 @@ describe('Math utils', () => {
   describe('PI_2', () => {
     it('should be equal to 2π', () => {
       expect(PI_2).to.equal(2 * Math.PI);
+    });
+  });
+
+  describe('sqr', () => {
+    it('should return the square of a number', () => {
+      expect(sqr(2)).to.equal(4);
+      expect(sqr(10)).to.equal(100);
+      expect(sqr(0)).to.equal(0);
+      expect(sqr(-1)).to.equal(1);
+
+      expect(sqr(0.123)).to.be.veryCloseTo(0.015129);
     });
   });
 
@@ -74,17 +83,6 @@ describe('Math utils', () => {
     });
   });
 
-  describe('sqr', () => {
-    it('should return the square of a number', () => {
-      expect(sqr(2)).to.equal(4);
-      expect(sqr(10)).to.equal(100);
-      expect(sqr(0)).to.equal(0);
-      expect(sqr(-1)).to.equal(1);
-
-      expect(sqr(0.123)).to.be.veryCloseTo(0.015129);
-    });
-  });
-
   describe('roundAngle', () => {
     it('should convert an angle in turns to the equivalent between 0 and 1', () => {
       expect(roundAngle(0.5)).to.equal(0.5);
@@ -94,6 +92,20 @@ describe('Math utils', () => {
 
       expect(roundAngle(100.123)).to.be.veryCloseTo(0.123);
       expect(roundAngle(-97.456)).to.be.veryCloseTo(0.544);
+    });
+  });
+
+  describe('getGap', () => {
+    it('should find the difference between two angles in turns', () => {
+      expect(getGap(0.5, 0)).to.be.veryCloseTo(0.5);
+      expect(getGap(1, 0.5)).to.be.veryCloseTo(0.5);
+      expect(getGap(0.6, 0.35)).to.be.veryCloseTo(0.25);
+    });
+
+    it('should return the shortest possible gap (i.e less than half a turn)', () => {
+      expect(getGap(0, 0.75)).to.be.veryCloseTo(0.25);
+      expect(getGap(2.5, 1)).to.be.veryCloseTo(0.5);
+      expect(getGap(-0.35, 1.6)).to.be.veryCloseTo(0.05);
     });
   });
 
@@ -160,65 +172,6 @@ describe('Math utils', () => {
 
       expect(acos(0.3)).to.be.closeTo(0.2015, LUT_TOLERANCE);
       expect(acos(-0.75)).to.be.closeTo(0.3850, LUT_TOLERANCE);
-    });
-  });
-
-  describe('isShorter', () => {
-    it('should compare the length of line segment to a set distance', () => {
-      expect(isShorter({ x1: 0, y1: 0, x2: 3, y2: 0 }, 4)).to.be.true;
-      expect(isShorter({ x1: 0, y1: 0, x2: 3, y2: 0 }, 2)).to.be.false;
-
-      expect(isShorter({ x1: 10, y1: 10, x2: 10, y2: 20 }, 11)).to.be.true;
-      expect(isShorter({ x1: 10, y1: 10, x2: 10, y2: 20 }, 9)).to.be.false;
-
-      expect(isShorter({ x1: 1, y1: 1, x2: 2, y2: 2 }, 1.415)).to.be.true;
-      expect(isShorter({ x1: 1, y1: 1, x2: 2, y2: 2 }, 1.413)).to.be.false;
-
-      expect(isShorter({ x1: 120, y1: 83, x2: 572, y2: 313 }, 508)).to.be.true;
-      expect(isShorter({ x1: 120, y1: 83, x2: 572, y2: 313 }, 506)).to.be.false;
-    });
-  });
-
-  describe('isCloser', () => {
-    it('should compare the shortest distance between a point a line to a set distance', () => {
-      expect(isCloser({ x: 2, y: 3 }, { x1: 0, y1: 0, x2: 4, y2: 0 }, 4)).to.be.true;
-      expect(isCloser({ x: 2, y: 3 }, { x1: 0, y1: 0, x2: 4, y2: 0 }, 2)).to.be.false;
-
-      expect(isCloser({ x: 20, y: 15 }, { x1: 10, y1: 10, x2: 10, y2: 20 }, 11)).to.be.true;
-      expect(isCloser({ x: 20, y: 15 }, { x1: 10, y1: 10, x2: 10, y2: 20 }, 9)).to.be.false;
-
-      expect(isCloser({ x: 2, y: 1 }, { x1: 1, y1: 1, x2: 2, y2: 2 }, 0.708)).to.be.true;
-      expect(isCloser({ x: 2, y: 1 }, { x1: 1, y1: 1, x2: 2, y2: 2 }, 0.706)).to.be.false;
-    });
-
-    it('should compare the shortest distance when the point is beyond the line', () => {
-      expect(isCloser({ x: 7, y: 0 }, { x1: 0, y1: 0, x2: 4, y2: 0 }, 4)).to.be.true;
-      expect(isCloser({ x: 7, y: 0 }, { x1: 0, y1: 0, x2: 4, y2: 0 }, 2)).to.be.false;
-
-      expect(isCloser({ x: 10, y: 0 }, { x1: 10, y1: 10, x2: 10, y2: 20 }, 11)).to.be.true;
-      expect(isCloser({ x: 10, y: 0 }, { x1: 10, y1: 10, x2: 10, y2: 20 }, 9)).to.be.false;
-
-      expect(isCloser({ x: 3, y: 3 }, { x1: 1, y1: 1, x2: 2, y2: 2 }, 1.415)).to.be.true;
-      expect(isCloser({ x: 3, y: 3 }, { x1: 1, y1: 1, x2: 2, y2: 2 }, 1.414)).to.be.false;
-    });
-
-    it('should compare the shortest distance when the line has a length of zero', () => {
-      expect(isCloser({ x: 95, y: 95 }, { x1: 100, y1: 100, x2: 100, y2: 100 }, 7.08)).to.be.true;
-      expect(isCloser({ x: 95, y: 95 }, { x1: 100, y1: 100, x2: 100, y2: 100 }, 7.06)).to.be.false;
-    });
-  });
-
-  describe('getGap', () => {
-    it('should find the difference between two angles in turns', () => {
-      expect(getGap(0.5, 0)).to.be.veryCloseTo(0.5);
-      expect(getGap(1, 0.5)).to.be.veryCloseTo(0.5);
-      expect(getGap(0.6, 0.35)).to.be.veryCloseTo(0.25);
-    });
-
-    it('should return the shortest possible gap (i.e less than half a turn)', () => {
-      expect(getGap(0, 0.75)).to.be.veryCloseTo(0.25);
-      expect(getGap(2.5, 1)).to.be.veryCloseTo(0.5);
-      expect(getGap(-0.35, 1.6)).to.be.veryCloseTo(0.05);
     });
   });
 


### PR DESCRIPTION
Simplifies and improves collision detection using the new `snapCircleToEdge` geometry utility. This removes the need for the previous collision hacks: calculating (and re-calculating) the next x/y coords, and tracking previous collision bodies. This makes the simulation code faster, easier to reason about, and eliminates most buggy collision states (such as three bodies overlapping).