### PR TITLE
Update headless runner and balance settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ evolve into new and different species better suited to their environment.
         - [Linter](#linter)
         - [Type Checker](#type-checker)
         - [Unit Tests](#unit-tests)
+        - [Headless Simulation](#headless-simulation)
 - [Contributing](#contributing)
 - [License](#license)
 - [Attribution](#attribution)
@@ -177,32 +178,32 @@ npm run unit-tests
 
 ### Headless Simulation
 
-To better evaluate the health of the simulation under default settings there it
-is possible to run Meeba Farm in a "headless" mode. This will run the
-simulation with a Node CLI and generate logs and CSV files with information
-about the meeba population. To run the default headless simulation, use:
+To better evaluate the health of the simulation under default settings, it is
+possible to run Meeba Farm in "headless" mode. This will run the simulation
+with a Node CLI and generate logs and CSV files with information about the
+meeba population. To run the default headless simulation, use:
 
 ```bash
 npm run headless
 ```
 
 This will run five tests at a variety of tank sizes, framerates, and duration
-of simulated time. You can use command line arguments to run one test with
+of simulated time. You can also use command line arguments to run one test with
 specific parameters:
 
 ```bash
 npm run headless -- duration [width=1000] [height=1000] [framerate=60]
 ```
 
-Replace the above parameters with a specific number. Note that duration must be
-specificied in _hours_ not milliseconds. For example:
+Replace one or more of the above parameters with a specific number. Note that
+the duration must be specified in _hours_ not milliseconds. For example:
 
 ```bash
 npm run headless -- 24 1920 1080
 ```
 
 The above would run for 24 hours of simulated time in a tank that was
-1920x1080.
+1920x1080, running at the default of 60fps.
 
 _Note: All CSV reports are stored in the [tests/reports/](./tests/reports)
 directory._

--- a/app/settings.js
+++ b/app/settings.js
@@ -136,18 +136,18 @@ export const settings = {
   },
   bodies: {
     initialEnergyAdjustment: 10,
-    minRadius: 10,
+    minRadius: 8,
     meebaLightness: 45,
     moteHue: 77,
     moteLightness: 33,
     moteRadius: 5,
     moteCalorieAdjustment: 2,
     moteSpeedAdjustment: 0.2,
-    spawningEnergyAdjustment: 5,
+    spawningEnergyAdjustment: 4,
   },
   genome: {
     averageGeneCount: 48,
-    averageGeneSize: 6,
+    averageGeneSize: 8,
     baseChanceMutateBit: 0.0005,
     baseChanceDropByte: 0.008,
     baseChanceRepeatByte: 0.008,
@@ -164,7 +164,7 @@ export const settings = {
     percentBlueGenes: 0.05,
   },
   settings: {
-    baseMoteSpawn: 32,
+    baseMoteSpawn: 36,
     baseStartingMeebas: 100,
   },
   simulation: {
@@ -177,16 +177,16 @@ export const settings = {
     bodySpawnInactiveTime: 2000,
   },
   spikes: {
-    baseSpikeDrain: 100000,
-    drainLengthExponent: 1.8,
+    baseSpikeDrain: 160000,
+    drainLengthExponent: 1.75,
     spikeWidth: 6,
   },
   vitals: {
     percentDiesAt: 0.5,
     percentSpawnsAt: 2,
-    baseUpkeepAdjustment: 0.8,
-    massCalorieExponent: 0.66, // Idealized Kleiber's law
-    spikeCountExponent: 1.7,
+    baseUpkeepAdjustment: 8,
+    massCalorieExponent: 0.9,
+    spikeCountExponent: 1.5,
     upkeepPerLength: 16,
     upkeepPerMass: 1,
     upkeepPerSpike: 32,

--- a/app/utils/diagnostics.js
+++ b/app/utils/diagnostics.js
@@ -2,6 +2,22 @@ import {
   flatten,
   groupBy,
 } from './arrays.js';
+import {
+  sum,
+  minimum,
+  maximum,
+  mean,
+  mode,
+} from './math.js';
+
+/**
+ * @typedef PropertyStats
+ *
+ * @prop {number} min
+ * @prop {number} max
+ * @prop {number} mean
+ * @prop {number} mode
+ */
 
 /**
  * @typedef Snapshot
@@ -9,35 +25,17 @@ import {
  * @prop {number} timestamp
  * @prop {number} meebas
  * @prop {number} motes
- * @prop {number} spikes
  * @prop {number} calories
- * @prop {number} averageSize
- * @prop {number} averageSpikes
- * @prop {number} averageSpikeLength
- * @prop {number} averageUpkeep
- * @prop {number} averageSpeed
- * @prop {number} averageMoteSpeed
+ * @prop {PropertyStats} size
+ * @prop {PropertyStats} spikeCount
+ * @prop {PropertyStats} spikeLength
+ * @prop {PropertyStats} upkeep
+ * @prop {PropertyStats} speed
  */
 
 /**
  * @typedef {import('../simulation.js').Body} Body
  */
-
-/**
- * @template T
- * @param {T[]} arr
- * @param {function(T): number} getValue
- * @returns {number}
- */
-const sum = (arr, getValue) => arr.reduce((total, item) => total + getValue(item), 0);
-
-/**
- * @template T
- * @param {T[]} arr
- * @param {function(T): number} getValue
- * @returns {number}
- */
-const avg = (arr, getValue) => (arr.length === 0 ? 0 : sum(arr, getValue) / arr.length);
 
 /**
  * @param {Body} body
@@ -54,6 +52,17 @@ const getBodyCategory = (body) => {
 
   return 'meebas';
 };
+
+/**
+ * @param {number[]} values - the assorted values a particular property
+ * @returns {PropertyStats}
+ */
+const analyzeProperty = values => ({
+  min: minimum(values),
+  max: maximum(values),
+  mean: mean(values),
+  mode: mode(values),
+});
 
 /**
  * Generate a report about the current state of the simulation
@@ -73,14 +82,12 @@ export const getSnapshot = (timestamp, bodies) => {
     timestamp,
     meebas: meebas.length,
     motes: motes.length,
-    spikes: spikes.length,
-    calories: sum(bodies, body => body.vitals.calories),
-    averageSize: avg(meebas, meeba => meeba.mass),
-    averageSpikes: avg(meebas, meeba => meeba.spikes.length),
-    averageSpikeLength: avg(spikes, spike => spike.length),
-    averageUpkeep: avg(meebas, meeba => meeba.vitals.upkeep),
-    averageSpeed: avg(meebas, meeba => meeba.velocity.speed),
-    averageMoteSpeed: avg(motes, mote => mote.velocity.speed),
+    calories: sum(bodies.map(body => body.vitals.calories)),
+    size: analyzeProperty(meebas.map(meeba => meeba.mass)),
+    spikeCount: analyzeProperty(meebas.map(meeba => meeba.spikes.length)),
+    spikeLength: analyzeProperty(spikes.map(spike => spike.length)),
+    upkeep: analyzeProperty(meebas.map(meeba => meeba.vitals.upkeep)),
+    speed: analyzeProperty(meebas.map(meeba => meeba.velocity.speed)),
   };
 };
 

--- a/app/utils/math.js
+++ b/app/utils/math.js
@@ -21,15 +21,64 @@ const LOOKUP_TABLES = {
 export const sqr = n => n * n;
 
 /**
+ * @param {function(number[]): number} fn
+ * @returns {function(number[]): number}
+ */
+const nanEmpties = (fn) => (nums) => (nums.length === 0 ? NaN : fn(nums));
+
+/**
+ * Returns the sum of an array of numbers
+ *
+ * @param {number[]} nums
+ * @returns {number}
+ */
+export const sum = nanEmpties(nums => nums.reduce((s, n) => s + n));
+
+/**
+ * Returns the least in an array of numbers
+ *
+ * @param {number[]} nums
+ * @returns {number}
+ */
+export const minimum = nanEmpties(nums => nums.reduce((min, n) => (min < n ? min : n)));
+
+/**
+ * Returns the most in an array of numbers
+ *
+ * @param {number[]} nums
+ * @returns {number}
+ */
+export const maximum = nanEmpties(nums => nums.reduce((max, n) => (max > n ? max : n)));
+
+/**
+ * Returns the average of an array of numbers
+ *
+ * @param {number[]} nums
+ * @returns {number}
+ */
+export const mean = nums => sum(nums) / nums.length;
+
+/**
+ * Returns the middle value in an array of numbers
+ *
+ * @param {number[]} nums
+ * @returns {number}
+ */
+export const mode = nanEmpties(
+  nums => nums.slice().sort((a, b) => a - b)[Math.floor((nums.length - 1) / 2)],
+);
+
+/**
  * Returns the sum of the products of two sets of numbers
  *
  * @param {number[]} set1
  * @param {number[]} set2
  * @returns {number}
  */
-export const dotProduct = (set1, set2) => set1
-  .map((n1, i) => n1 * set2[i])
-  .reduce((sum, n) => sum + n);
+export const dotProduct = (set1, set2) => {
+  const products = set1.map((n1, i) => n1 * set2[i]);
+  return sum(products);
+};
 
 /**
  * Rounds a number to be no less or more than a min and max

--- a/app/utils/objects.js
+++ b/app/utils/objects.js
@@ -109,6 +109,35 @@ export const listValues = (obj) => {
 };
 
 /**
+ * Converts an array of key/value pairs into an object
+ *
+ * @param {Array<[string, any]>} entries - array of key/value pairs
+ * @returns {Object<string, any>}
+ */
+export const fromEntries = (entries) => {
+  const obj = /** @type {Object<string, any>} */ ({});
+  for (const [key, val] of entries) {
+    obj[key] = val;
+  }
+  return obj;
+};
+
+/**
+ * Converts an array of keys and an array of values to an object
+ *
+ * @param {string[]} keys - array of keys
+ * @param {array} values - array of values
+ * @returns {Object<string, any>}
+ */
+export const fromLists = (keys, values) => {
+  const obj = /** @type {Object<string, any>} */ ({});
+  for (let i = 0; i < keys.length; i += 1) {
+    obj[keys[i]] = values[i];
+  }
+  return obj;
+};
+
+/**
  * Returns a function which will mutate an object's properties over time
  *
  * @param {Object<string, any>} target - the object to mutate

--- a/tests/app/utils/diagnostics.test.js
+++ b/tests/app/utils/diagnostics.test.js
@@ -166,6 +166,59 @@ const TEST_BODIES = [
     },
   },
   {
+    dna: 'F09849F244CF070278DDBE530A4F1D9D9166666F1D9D91',
+    fill: {
+      h: 240,
+      s: 29,
+      l: 50,
+    },
+    x: 300,
+    y: 200,
+    radius: 13,
+    mass: 533,
+    velocity: {
+      angle: 0.35,
+      speed: 6,
+    },
+    vitals: {
+      calories: 313,
+      upkeep: 30,
+      diesAt: 266,
+      spawnsAt: 1066,
+      isDead: false,
+    },
+    spikes: [
+      {
+        drain: 200,
+        fill: {
+          h: 0,
+          s: 100,
+          l: 0,
+        },
+        angle: 0.5,
+        length: 12,
+        x1: 275,
+        y1: 300,
+        x2: 288,
+        y2: 303,
+        x3: 288,
+        y3: 297,
+        offset: {
+          x1: -25,
+          y1: 0,
+          x2: -12,
+          y2: 3,
+          x3: -12,
+          y3: -3,
+        },
+      },
+    ],
+    meta: {
+      canInteract: true,
+      isSimulated: true,
+    },
+  },
+  {
     dna: '',
     fill: {
       h: 77,
@@ -228,16 +281,39 @@ describe('Diagnostics module', () => {
     it('should generate a report summarizing the current state of the simulation', () => {
       expect(getSnapshot(123.45, TEST_BODIES)).to.deep.equal({
         timestamp: 123.45,
-        meebas: 2,
+        meebas: 3,
         motes: 3,
-        calories: 2379,
-        spikes: 3,
-        averageSize: 785,
-        averageSpikes: 1.5,
-        averageSpikeLength: 16,
-        averageUpkeep: 36,
-        averageSpeed: 9,
-        averageMoteSpeed: 15,
+        calories: 2692,
+        size: {
+          min: 314,
+          max: 1256,
+          mode: 533,
+          mean: 701,
+        },
+        spikeCount: {
+          min: 1,
+          max: 2,
+          mode: 1,
+          mean: 1.3333333333333333,
+        },
+        spikeLength: {
+          min: 8,
+          max: 20,
+          mode: 12,
+          mean: 15,
+        },
+        upkeep: {
+          min: 24,
+          max: 48,
+          mode: 30,
+          mean: 34,
+        },
+        speed: {
+          min: 6,
+          max: 12,
+          mode: 6,
+          mean: 8,
+        },
       });
     });
 
@@ -246,14 +322,12 @@ describe('Diagnostics module', () => {
         timestamp: 0,
         meebas: 0,
         motes: 0,
-        spikes: 0,
-        calories: 0,
-        averageSize: 0,
-        averageSpikes: 0,
-        averageSpikeLength: 0,
-        averageUpkeep: 0,
-        averageSpeed: 0,
-        averageMoteSpeed: 0,
+        calories: NaN,
+        size: { min: NaN, max: NaN, mode: NaN, mean: NaN },
+        spikeCount: { min: NaN, max: NaN, mode: NaN, mean: NaN },
+        spikeLength: { min: NaN, max: NaN, mode: NaN, mean: NaN },
+        upkeep: { min: NaN, max: NaN, mode: NaN, mean: NaN },
+        speed: { min: NaN, max: NaN, mode: NaN, mean: NaN },
       });
     });
   });

--- a/tests/app/utils/diagnostics.test.js
+++ b/tests/app/utils/diagnostics.test.js
@@ -8,8 +8,12 @@ const {
 
 const TEST_BODIES = [
   {
-    dna: 'F09849F044CF070278DDBE530A4F1D9D9166666',
-    fill: '#6b6e90',
+    dna: 'F07849F044CF070278DDBE530A4F1D9D9166666',
+    fill: {
+      h: 0,
+      s: 60,
+      l: 50,
+    },
     x: 100,
     y: 200,
     radius: 20,
@@ -28,7 +32,12 @@ const TEST_BODIES = [
     spikes: [
       {
         drain: 200,
-        fill: 'black',
+        fill: {
+          h: 0,
+          s: 100,
+          l: 0,
+        },
+        angle: 0,
         length: 20,
         x1: 100,
         y1: 154,
@@ -44,18 +53,20 @@ const TEST_BODIES = [
           x3: -3,
           y3: -22,
         },
-        meta: { deactivateTime: null },
       },
     ],
     meta: {
-      nextX: 100,
-      nextY: 200,
-      lastCollisionBody: null,
+      canInteract: true,
+      isSimulated: true,
     },
   },
   {
     dna: '',
-    fill: '#792',
+    fill: {
+      h: 77,
+      s: 40,
+      l: 50,
+    },
     x: 200,
     y: 100,
     radius: 5,
@@ -65,22 +76,25 @@ const TEST_BODIES = [
       speed: 5,
     },
     vitals: {
-      calories: 158,
+      calories: 63,
       upkeep: 0,
       diesAt: 0,
-      spawnsAt: 9007199254740991,
+      spawnsAt: 159,
       isDead: false,
     },
     spikes: [],
     meta: {
-      nextX: 200,
-      nextY: 100,
-      lastCollisionBody: null,
+      canInteract: true,
+      isSimulated: true,
     },
   },
   {
-    dna: 'F09849F244CF070278DDBE530A4F1D9D9166666F1D9D91',
-    fill: '#bb6e00',
+    dna: 'F08849F244CF070278DDBE530A4F1D9D9166666F1D9D91',
+    fill: {
+      h: 120,
+      s: 80,
+      l: 50,
+    },
     x: 200,
     y: 300,
     radius: 10,
@@ -99,7 +113,12 @@ const TEST_BODIES = [
     spikes: [
       {
         drain: 200,
-        fill: 'black',
+        fill: {
+          h: 0,
+          s: 100,
+          l: 0,
+        },
+        angle: 0.25,
         length: 8,
         x1: 200,
         y1: 277,
@@ -115,11 +134,15 @@ const TEST_BODIES = [
           x3: -3,
           y3: -11,
         },
-        meta: { deactivateTime: null },
       },
       {
         drain: 200,
-        fill: 'black',
+        fill: {
+          h: 0,
+          s: 100,
+          l: 0,
+        },
+        angle: 0.5,
         length: 20,
         x1: 200,
         y1: 254,
@@ -135,18 +158,20 @@ const TEST_BODIES = [
           x3: -3,
           y3: -22,
         },
-        meta: { deactivateTime: null },
       },
     ],
     meta: {
-      nextX: 200,
-      nextY: 300,
-      lastCollisionBody: null,
+      canInteract: true,
+      isSimulated: true,
     },
   },
   {
     dna: '',
-    fill: '#792',
+    fill: {
+      h: 77,
+      s: 99,
+      l: 50,
+    },
     x: 300,
     y: 200,
     radius: 5,
@@ -159,19 +184,22 @@ const TEST_BODIES = [
       calories: 158,
       upkeep: 0,
       diesAt: 0,
-      spawnsAt: 9007199254740991,
+      spawnsAt: 159,
       isDead: false,
     },
     spikes: [],
     meta: {
-      nextX: 300,
-      nextY: 200,
-      lastCollisionBody: null,
+      canInteract: true,
+      isSimulated: true,
     },
   },
   {
     dna: '',
-    fill: '#792',
+    fill: {
+      h: 77,
+      s: 99,
+      l: 50,
+    },
     x: 200,
     y: 200,
     radius: 5,
@@ -184,14 +212,13 @@ const TEST_BODIES = [
       calories: 158,
       upkeep: 0,
       diesAt: 0,
-      spawnsAt: 9007199254740991,
+      spawnsAt: 159,
       isDead: false,
     },
     spikes: [],
     meta: {
-      nextX: 200,
-      nextY: 200,
-      lastCollisionBody: null,
+      canInteract: true,
+      isSimulated: true,
     },
   },
 ];
@@ -203,8 +230,8 @@ describe('Diagnostics module', () => {
         timestamp: 123.45,
         meebas: 2,
         motes: 3,
+        calories: 2379,
         spikes: 3,
-        calories: 2474,
         averageSize: 785,
         averageSpikes: 1.5,
         averageSpikeLength: 16,
@@ -232,7 +259,7 @@ describe('Diagnostics module', () => {
   });
 
   describe('toCsv', () => {
-    it('should convert an array of objects into a CVS string', () => {
+    it('should convert an array of objects into a CSV string', () => {
       const objects = [
         { foo: 1, bar: 2, baz: 'qux' },
         { foo: 3, bar: 4, baz: 'quux' },

--- a/tests/app/utils/math.test.js
+++ b/tests/app/utils/math.test.js
@@ -5,6 +5,11 @@ const { range } = require('./arrays.common.js');
 const {
   PI_2,
   sqr,
+  sum,
+  minimum,
+  maximum,
+  mean,
+  mode,
   dotProduct,
   roundRange,
   normalize,
@@ -37,6 +42,102 @@ describe('Math utils', () => {
       expect(sqr(-1)).to.equal(1);
 
       expect(sqr(0.123)).to.be.veryCloseTo(0.015129);
+    });
+  });
+
+  describe('sum', () => {
+    it('should return the sum of an array of numbers', () => {
+      expect(sum([1, 2, 3, 4])).to.equal(10);
+      expect(sum([4, 1, 3, 2])).to.equal(10);
+      expect(sum([1])).to.equal(1);
+      expect(sum([5, 3.1, 178, -5, 8])).to.equal(189.1);
+    });
+
+    it('should return NaN if passed an empty array', () => {
+      expect(sum([])).to.be.NaN;
+    });
+
+    it('should not mutate the passed array', () => {
+      const numbers = [4, 1, 3, 2];
+      sum(numbers);
+      expect(numbers).to.deep.equal([4, 1, 3, 2]);
+    });
+  });
+
+  describe('minimum', () => {
+    it('should return the least of an array of numbers', () => {
+      expect(minimum([1, 2, 3, 4])).to.equal(1);
+      expect(minimum([4, 1, 3, 2])).to.equal(1);
+      expect(minimum([1])).to.equal(1);
+      expect(minimum([5, 3.1, 178, -5, 8])).to.equal(-5);
+    });
+
+    it('should return NaN if passed an empty array', () => {
+      expect(minimum([])).to.be.NaN;
+    });
+
+    it('should not mutate the passed array', () => {
+      const numbers = [4, 1, 3, 2];
+      minimum(numbers);
+      expect(numbers).to.deep.equal([4, 1, 3, 2]);
+    });
+  });
+
+  describe('maximum', () => {
+    it('should return the highest of an array of numbers', () => {
+      expect(maximum([1, 2, 3, 4])).to.equal(4);
+      expect(maximum([4, 1, 3, 2])).to.equal(4);
+      expect(maximum([1])).to.equal(1);
+      expect(maximum([5, 3.1, 178, -5, 8])).to.equal(178);
+    });
+
+    it('should return NaN if passed an empty array', () => {
+      expect(maximum([])).to.be.NaN;
+    });
+
+    it('should not mutate the passed array', () => {
+      const numbers = [4, 1, 3, 2];
+      maximum(numbers);
+      expect(numbers).to.deep.equal([4, 1, 3, 2]);
+    });
+  });
+
+  describe('mean', () => {
+    it('should return the average of an array of numbers', () => {
+      expect(mean([1, 2, 3, 4])).to.equal(2.5);
+      expect(mean([4, 1, 3, 2])).to.equal(2.5);
+      expect(mean([1])).to.equal(1);
+      expect(mean([5, 3.1, 178, -5, 8])).to.equal(37.82);
+    });
+
+    it('should return NaN if passed an empty array', () => {
+      expect(mean([])).to.be.NaN;
+    });
+
+    it('should not mutate the passed array', () => {
+      const numbers = [4, 1, 3, 2];
+      mean(numbers);
+      expect(numbers).to.deep.equal([4, 1, 3, 2]);
+    });
+  });
+
+  describe('mode', () => {
+    it('should return the middle value in an array of numbers', () => {
+      expect(mode([1, 2, 4])).to.equal(2);
+      expect(mode([4, 1, 2])).to.equal(2);
+      expect(mode([1, 2, 3, 4])).to.equal(2);
+      expect(mode([1])).to.equal(1);
+      expect(mode([5, 3.1, 178, -5, 8])).to.equal(5);
+    });
+
+    it('should return NaN if passed an empty array', () => {
+      expect(mode([])).to.be.NaN;
+    });
+
+    it('should not mutate the passed array', () => {
+      const numbers = [4, 1, 2];
+      mode(numbers);
+      expect(numbers).to.deep.equal([4, 1, 2]);
     });
   });
 

--- a/tests/app/utils/objects.test.js
+++ b/tests/app/utils/objects.test.js
@@ -9,6 +9,8 @@ const {
   setNested,
   listKeys,
   listValues,
+  fromEntries,
+  fromLists,
   getTweener,
 } = require('./objects.common.js');
 
@@ -205,6 +207,48 @@ describe('Object utils', () => {
       });
 
       expect(keys).to.deep.equal([{}, undefined, 7]);
+    });
+  });
+
+  describe('fromEntries', () => {
+    it('should convert an array of key value pairs to an object', () => {
+      expect(fromEntries([['foo', false], ['bar', 7], ['baz', ['corge']]])).to.deep.equal({
+        foo: false,
+        bar: 7,
+        baz: ['corge'],
+      });
+    });
+
+    it('should set a value to undefined when is missing', () => {
+      expect(fromEntries([['foo']])).to.deep.equal({
+        foo: undefined,
+      });
+    });
+
+    it('should throw when passed an invalid entry', () => {
+      expect(() => fromEntries([null])).to.throw;
+    });
+  });
+
+  describe('fromLists', () => {
+    it('should convert an array of keys and an array of values to an object', () => {
+      expect(fromLists(['foo', 'bar', 'baz'], [false, 7, ['corge']])).to.deep.equal({
+        foo: false,
+        bar: 7,
+        baz: ['corge'],
+      });
+    });
+
+    it('should set a value to undefined when value is missing', () => {
+      expect(fromLists(['foo'], [])).to.deep.equal({
+        foo: undefined,
+      });
+    });
+
+    it('should skip values when key is missing', () => {
+      expect(fromLists(['foo'], ['bar', 'baz'])).to.deep.equal({
+        foo: 'bar',
+      });
     });
   });
 

--- a/tests/run-headless.js
+++ b/tests/run-headless.js
@@ -11,7 +11,6 @@ const {
   restoreDefaultSettings,
 } = require('./app/settings.common.js');
 const {
-  separateBodies,
   simulateFrame,
 } = require('./app/simulation.common.js');
 const {
@@ -111,7 +110,6 @@ const run = (duration, width, height, framerate) => {
 
   const snapshots = [];
   let bodies = range(settings.core.startingMeebaCount).map(getRandomBody);
-  separateBodies(bodies);
 
   let time = 0;
   let nextSnapshot = 0;

--- a/tests/run-headless.js
+++ b/tests/run-headless.js
@@ -27,6 +27,11 @@ const {
 const {
   seedPrng,
 } = require('./app/utils/math.common.js');
+const {
+  listKeys,
+  listValues,
+  fromLists,
+} = require('./app/utils/objects.common.js');
 
 const SEC = 1000;
 const MIN = 60 * SEC;
@@ -78,17 +83,49 @@ const logFormatted = (...args) => {
   console.log(formatString, ...messages);
 };
 
-const logSnapshot = (snapshot) => {
-  for (const [key, value] of Object.entries(snapshot)) {
-    const roundedValue = Math.floor(value * 1000) / 1000;
-    logFormatted(`${key}: `, [], roundedValue, ['dim']);
+const logKeyVal = (key, val) => logFormatted(`${key}: `, [], val, ['dim']);
+
+const truncate = val => Math.floor(val * 100) / 100;
+const logTruncated = (key, val) => logKeyVal(key, truncate(val));
+const padTruncated = (val, size) => String(truncate(val)).padStart(size, ' ');
+
+const logSnapshot = ({ timestamp, meebas, motes, calories, ...propStats }) => {
+  logTruncated('timestamp', timestamp);
+  logTruncated('meebas', meebas);
+  logTruncated('motes', motes);
+  logTruncated('calories', calories);
+
+  logFormatted('-------------+---------+---------+---------+---------', []);
+  logFormatted('Prop Stats   |   min   |   max   |   mean  |   mode  ', []);
+  logFormatted('-------------+---------+---------+---------+---------', []);
+
+  for (const [prop, stats] of Object.entries(propStats)) {
+    logFormatted(
+      prop.padEnd(12, ' '), [],
+      ' | ', [],
+      padTruncated(stats.min, 7), ['dim'],
+      ' | ', ['reset'],
+      padTruncated(stats.max, 7), ['dim'],
+      ' | ', ['reset'],
+      padTruncated(stats.mean, 7), ['dim'],
+      ' | ', ['reset'],
+      padTruncated(stats.mode, 7), ['dim'],
+    );
   }
 };
 
 const getReportPath = (...identifiers) => `headless-${identifiers.join('-')}.csv`;
 
+const flattenSnapshot = (snapshot) => {
+  // Get snapshot keys camelCased instead of dot-separated
+  const snapshotKeys = listKeys(snapshot)
+    .map(key => key.replace(/\.(.)/g, (_, first) => first.toUpperCase()));
+  const snapshotValues = listValues(snapshot);
+  return fromLists(snapshotKeys, snapshotValues);
+};
+
 const writeReport = (path, snapshots) => {
-  const report = toCsv(snapshots);
+  const report = toCsv(snapshots.map(flattenSnapshot));
   writeFileSync(resolve(REPORT_DIR, path), report);
 };
 
@@ -105,7 +142,7 @@ const run = (duration, width, height, framerate) => {
 
   const { seed } = settings.core;
   seedPrng(seed);
-  logFormatted('seed: ', [], seed, ['dim']);
+  logKeyVal('seed', seed);
   console.log();
 
   const snapshots = [];


### PR DESCRIPTION
The headless runner had fallen a bit out of date since the last time I ran it, and was missing some key features like the min, max, and mode for various stats. This updates the runner, and then used it to take another crack at the default settings. The new defaults greatly increase the efficiency of larger meebas so they will no longer bottom out for size. This should be the last settings update until they are overhauled as a part of Issue #60.