### PR TITLE
Start simulations with more dramatic conditions/animations

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -89,6 +89,7 @@
                 "onclick",
                 "outliner",
                 "pipeable",
+                "pre",
                 "prng",
                 "px",
                 "qux",

--- a/app/settings.js
+++ b/app/settings.js
@@ -81,6 +81,7 @@ import {
 /**
  * @typedef StartupSettings
  * @prop {number} meebaSpawnDelay
+ * @prop {number} meebaSpawnDuration
  * @prop {number} moteCalorieDensity
  * @prop {number} moteFadeInTime
  * @prop {number} moteSpawnDelay
@@ -196,6 +197,7 @@ export const settings = {
   },
   startup: {
     meebaSpawnDelay: 1000,
+    meebaSpawnDuration: 6000,
     moteCalorieDensity: 0.05,
     moteFadeInTime: 2500,
     moteSpawnDelay: 500,

--- a/app/settings.js
+++ b/app/settings.js
@@ -80,6 +80,7 @@ import {
 
 /**
  * @typedef StartupSettings
+ * @prop {number} meebaSpawnDelay
  * @prop {number} moteCalorieDensity
  * @prop {number} moteFadeInTime
  * @prop {number} moteSpawnDelay
@@ -194,6 +195,7 @@ export const settings = {
     spikeWidth: 6,
   },
   startup: {
+    meebaSpawnDelay: 1000,
     moteCalorieDensity: 0.05,
     moteFadeInTime: 2500,
     moteSpawnDelay: 500,

--- a/app/settings.js
+++ b/app/settings.js
@@ -177,7 +177,7 @@ export const settings = {
   },
   settings: {
     baseMoteSpawn: 36,
-    baseStartingMeebas: 100,
+    baseStartingMeebas: 50,
   },
   simulation: {
     maxBodies: 1000,

--- a/app/settings.js
+++ b/app/settings.js
@@ -79,6 +79,13 @@ import {
  */
 
 /**
+ * @typedef StartupSettings
+ * @prop {number} moteCalorieDensity
+ * @prop {number} moteFadeInTime
+ * @prop {number} moteSpawnDelay
+ */
+
+/**
  * @typedef VitalsModuleSettings
  * @prop {number} percentDiesAt
  * @prop {number} percentSpawnsAt
@@ -100,6 +107,7 @@ import {
  * @prop {SettingsModuleSettings} settings
  * @prop {SimulationModuleSettings} simulation
  * @prop {SpikesModuleSettings} spikes
+ * @prop {StartupSettings} startup
  * @prop {VitalsModuleSettings} vitals
  */
 
@@ -184,6 +192,11 @@ export const settings = {
     baseSpikeDrain: 160000,
     drainLengthExponent: 1.75,
     spikeWidth: 6,
+  },
+  startup: {
+    moteCalorieDensity: 0.05,
+    moteFadeInTime: 2500,
+    moteSpawnDelay: 500,
   },
   vitals: {
     percentDiesAt: 0.5,

--- a/app/simulation.js
+++ b/app/simulation.js
@@ -436,19 +436,19 @@ const getNewMotes = (delay) => {
  * Gets a function to calculate a "frame" of the simulation
  *
  * @param {Body[]} bodies - all the bodies to simulate
- * @param {number} start - the timestamp of the previous frame
- * @param {number} stop - the timestamp of the current frame
+ * @param {number} tick - the timestamp of the current frame
+ * @param {number} msDelay - time elapsed since last frame
  * @returns {Body[]} - new array with inactive bodies removed
  */
-export const simulateFrame = (bodies, start, stop) => {
-  const delay = Math.min((stop - start) / 1000, MAX_TIME_PER_FRAME);
+export const simulateFrame = (bodies, tick, msDelay) => {
+  const delay = Math.min(msDelay / 1000, MAX_TIME_PER_FRAME);
 
-  const interactBodies = getBodyInteractor(bodies, delay, stop);
+  const interactBodies = getBodyInteractor(bodies, delay, tick);
   const moveBody = getBodyMover(delay);
   const upkeepCalories = getCalorieUpkeeper(delay);
-  const checkDeath = getDeathChecker(stop);
-  const checkRemoval = getRemovalChecker(stop);
-  const spawnChildren = getChildSpawner(stop);
+  const checkDeath = getDeathChecker(tick);
+  const checkRemoval = getRemovalChecker(tick);
+  const spawnChildren = getChildSpawner(tick);
 
   bodies.forEach(bounceWallIfPast);
   bodies.forEach(interactBodies);
@@ -459,7 +459,7 @@ export const simulateFrame = (bodies, start, stop) => {
   bodies.forEach(checkRemoval);
 
   // Run tweens and remove if done
-  tweens = tweens.filter(tween => tween(stop));
+  tweens = tweens.filter(tween => tween(tick));
 
   const newMotes = bodies.length < dynamic.bodyLimit ? getNewMotes(delay) : [];
   const newChildren = flatMap(bodies, spawnChildren);

--- a/app/simulation.js
+++ b/app/simulation.js
@@ -212,10 +212,9 @@ const collideIfOverlapping = (body1, body2) => {
  * drains calories as needed
  *
  * @param {number} delay - the time since the last tick
- * @param {number} tick - the current timestamp
  * @returns {function(Body, Body): void} - mutates bodies and spikes as needed
  */
-const getSpikeActivator = (delay, tick) => (body, other) => {
+const getSpikeActivator = (delay) => (body, other) => {
   if (!body.vitals.isDead) {
     const isSpikeOverlapping = getSpikeOverlapChecker(body, other);
     for (const spike of body.spikes) {
@@ -225,7 +224,7 @@ const getSpikeActivator = (delay, tick) => (body, other) => {
         fill.l = 50;
         const highlightTween = getTweener(fill)
           .addFrame(fixed.spikeHighlightTime, { l: 0 })
-          .start(tick);
+          .start();
         tweens.push(highlightTween);
 
         const drainAmount = drainCalories(other.vitals, Math.floor(spike.drain * delay));
@@ -243,12 +242,11 @@ const getSpikeActivator = (delay, tick) => (body, other) => {
  *
  * @param {Body[]} bodies - all bodies in the simulation
  * @param {number} delay - the time since the last tick
- * @param {number} tick - the current timestamp
  * @returns {function(Body): void} - mutates bodies as needed
  */
-const getBodyInteractor = (bodies, delay, tick) => {
+const getBodyInteractor = (bodies, delay) => {
   const interactiveBodies = bodies.filter(({ meta }) => meta.canInteract);
-  const activateSpikesIfValid = getSpikeActivator(delay, tick);
+  const activateSpikesIfValid = getSpikeActivator(delay);
 
   return (body) => {
     if (body.meta.canInteract) {
@@ -337,22 +335,21 @@ const getDeathChecker = (tick) => (body) => {
 };
 
 /**
- * Gets a function which will checks if a body should be removed, if so
- * adds removal tweens which will eventually mark the body to be removed
+ * A function to check if a body should be removed, and if so adds tweens
+ * which will eventually mark the body to be removed
  *
- * @param {number} tick - the current timestamp
- * @returns {function(Body): void}
+ * @param {Body} body - the current timestamp
  */
-const getRemovalChecker = (tick) => ({ fill, vitals, meta }) => {
+const checkBodyRemoval = ({ fill, vitals, meta }) => {
   if (meta.canInteract && vitals.calories <= 0) {
     meta.canInteract = false;
 
     const fadeTween = getTweener(fill)
       .addFrame(fixed.bodyRemovalFadeTime, { a: 0 })
-      .start(tick);
+      .start();
     const removeTween = getTweener(meta)
       .addFrame(dynamic.maxTotalFadeTime, { isSimulated: false })
-      .start(tick);
+      .start();
 
     tweens.push(fadeTween, removeTween);
   }
@@ -443,11 +440,10 @@ const getNewMotes = (delay) => {
 export const simulateFrame = (bodies, tick, msDelay) => {
   const delay = Math.min(msDelay / 1000, MAX_TIME_PER_FRAME);
 
-  const interactBodies = getBodyInteractor(bodies, delay, tick);
+  const interactBodies = getBodyInteractor(bodies, delay);
   const moveBody = getBodyMover(delay);
   const upkeepCalories = getCalorieUpkeeper(delay);
   const checkDeath = getDeathChecker(tick);
-  const checkRemoval = getRemovalChecker(tick);
   const spawnChildren = getChildSpawner(tick);
 
   bodies.forEach(bounceWallIfPast);
@@ -456,7 +452,7 @@ export const simulateFrame = (bodies, tick, msDelay) => {
   bodies.forEach(upkeepCalories);
   bodies.forEach(adjustSaturation);
   bodies.forEach(checkDeath);
-  bodies.forEach(checkRemoval);
+  bodies.forEach(checkBodyRemoval);
 
   // Run tweens and remove if done
   tweens = tweens.filter(tween => tween(tick));

--- a/app/utils/diagnostics.js
+++ b/app/utils/diagnostics.js
@@ -9,6 +9,10 @@ import {
   mean,
   mode,
 } from './math.js';
+import {
+  listKeys,
+  listValues,
+} from './objects.js';
 
 /**
  * @typedef PropertyStats
@@ -108,9 +112,9 @@ export const toCsv = (objArray) => {
     return '';
   }
 
-  const keys = Object.keys(objArray[0]).sort();
+  const keys = listKeys(objArray[0]);
   const csValues = objArray
-    .map(obj => stringify(keys.map(key => obj[key])))
+    .map(obj => stringify(listValues(obj)))
     .join('\n');
 
   return `${stringify(keys)}\n${csValues}`;

--- a/app/utils/loop.js
+++ b/app/utils/loop.js
@@ -1,0 +1,59 @@
+/**
+ * @callback FrameRunner
+ * @param {number} [tick] - timestamp of current frame of the loop in ms
+ * @param {number} [delay] - time elapsed since the last frame
+ */
+
+/**
+ * @typedef LoopControls
+ * @prop {function(): void} start - begin the loop or resume if paused
+ * @prop {function(): void} stop - pause loop execution and timestamp incrementing
+ * @prop {function(): void} reset - reset the timestamp to zero
+ */
+
+/**
+ * Takes a callback to be run on each frame and creates a loop with requestAnimationFrame.
+ * Returns an object with three control methods to start, stop, and reset the loop
+ *
+ * @param {FrameRunner} onFrame - callback to be run on each frame
+ * @returns {LoopControls}
+ */
+export const createLoop = (onFrame) => {
+  let isRunning = false;
+  let lastFrame = 0;
+  let lastStopped = 0;
+  let stoppedTime = 0;
+
+  /** @param {number} timestamp */
+  const loop = (timestamp) => {
+    if (isRunning) {
+      onFrame(timestamp - stoppedTime, timestamp - lastFrame);
+      lastFrame = timestamp;
+      requestAnimationFrame(loop);
+    }
+  };
+
+  const start = () => {
+    if (!isRunning) {
+      isRunning = true;
+      requestAnimationFrame((timestamp) => {
+        lastFrame = timestamp;
+        stoppedTime += timestamp - lastStopped;
+        requestAnimationFrame(loop);
+      });
+    }
+  };
+
+  const stop = () => {
+    if (isRunning) {
+      isRunning = false;
+      lastStopped = lastFrame;
+    }
+  };
+
+  const reset = () => {
+    stoppedTime = lastFrame;
+  };
+
+  return { start, stop, reset };
+};

--- a/app/utils/tweens.js
+++ b/app/utils/tweens.js
@@ -63,7 +63,7 @@ import {
 /**
  * @callback StartTween
  *
- * @param {number} start - the starting point, typically timestamp
+ * @param {number} [start] - starting point, typically a timestamp, set on first tween if omitted
  * @returns {Tweener} tween - progressively applies transforms
  */
 
@@ -172,11 +172,12 @@ const parseTransform = (target, transform, parents = []) => flatMap(
 
 /**
  * Builds the final tween function from a target object, a series of key frames,
- * and an initial start value
+ * and an optional initial start value
  *
  * @param {Object<string, any>} target - the object to mutate
  * @param {TweenFrame[]} frames - the frames already added
- * @param {number} firstStart - the initial start value, typically a timestamp
+ * @param {number} [firstStart] - the initial start value, typically a timestamp,
+ *                                set on first tween if omitted
  * @returns {Tweener} tween
  */
 const buildTweener = (target, frames, firstStart) => {
@@ -201,6 +202,10 @@ const buildTweener = (target, frames, firstStart) => {
   return /** @type {Tweener} */ function tween(current) {
     if (!targetRef) {
       return false;
+    }
+
+    if (start === undefined) {
+      start = current;
     }
 
     if (propTransforms.length > 0) {

--- a/app/utils/tweens.js
+++ b/app/utils/tweens.js
@@ -39,6 +39,12 @@ import {
  */
 
 /**
+ * @callback TimedCallback
+ *
+ * @param {number} [current] - the current value being tweened with (i.e. timestamp)
+ */
+
+/**
  * @typedef TweenBuilder
  *
  * @prop {AddFrame} addFrame - method for adding new frames
@@ -256,3 +262,67 @@ const getTweenBuilder = (target, frames) => ({
  * @returns {TweenBuilder}
  */
 export const getTweener = target => getTweenBuilder(target, []);
+
+/**
+ * Creates a tweener that replicates the behavior of setTimeout, calling a callback
+ * after a certain start value is reached
+ *
+ * @param {TimedCallback} callback - a function to call once the start is reached
+ * @param {number} delay - wait before triggering the callback
+ * @returns {Tweener}
+ */
+export const getTimeout = (callback, delay) => {
+  /**
+  * Enclosing a nullable reference to the callback
+  * @type {TimedCallback|null}
+  */
+  let callbackRef = callback;
+
+  /** @type {number} */
+  let start;
+
+  return function timeout(current) {
+    if (!callbackRef) {
+      return false;
+    }
+
+    if (start === undefined) {
+      start = current + delay;
+    }
+
+    if (current >= start) {
+      callbackRef(current);
+      callbackRef = null;
+      return false;
+    }
+
+    return true;
+  };
+};
+
+/**
+ * Creates a tweener that replicates the behavior of setInterval, repeatedly calling
+ * a callback each time a duration is passed
+ *
+ * @param {TimedCallback} callback - a function to call once the start is reached
+ * @param {number} duration - how long each interval should last
+ * @returns {Tweener}
+ */
+export const getInterval = (callback, duration) => {
+  /** @type {number} */
+  let next;
+
+  return function interval(current) {
+    if (next === undefined) {
+      next = current + duration;
+    }
+
+    if (current >= next) {
+      next += duration;
+      callback(current);
+      interval(current);
+    }
+
+    return true;
+  };
+};

--- a/tests/app/utils/diagnostics.test.js
+++ b/tests/app/utils/diagnostics.test.js
@@ -333,7 +333,7 @@ describe('Diagnostics module', () => {
   });
 
   describe('toCsv', () => {
-    it('should convert an array of objects into a CSV string', () => {
+    it('should convert an array of objects into a sorted CSV string', () => {
       const objects = [
         { foo: 1, bar: 2, baz: 'qux' },
         { foo: 3, bar: 4, baz: 'quux' },
@@ -341,6 +341,17 @@ describe('Diagnostics module', () => {
       ];
 
       expect(toCsv(objects)).to.equal('"bar","baz","foo"\n2,"qux",1\n4,"quux",3\n6,"quuz",5');
+    });
+
+    it('should convert an array of nested objects into a flat CSV string', () => {
+      const objects = [
+        { foo: 1, bar: { baz: 2, corge: 'qux' } },
+        { foo: 3, bar: { baz: 4, corge: 'quux' } },
+        { foo: 5, bar: { baz: 6, corge: 'quuz' } },
+      ];
+
+      expect(toCsv(objects))
+        .to.equal('"bar.baz","bar.corge","foo"\n2,"qux",1\n4,"quux",3\n6,"quuz",5');
     });
   });
 });

--- a/tests/app/utils/loop.test.js
+++ b/tests/app/utils/loop.test.js
@@ -1,0 +1,77 @@
+'use strict';
+
+const { expect } = require('chai');
+const sinon = require('sinon');
+const {
+  createLoop,
+} = require('./loop.common.js');
+
+describe('Game loop utils', () => {
+  describe('createLoop', () => {
+    let clock;
+
+    beforeEach(() => {
+      clock = sinon.useFakeTimers();
+    });
+
+    afterEach(() => {
+      clock.restore();
+    });
+
+    it('should take a callback function and return control methods', () => {
+      const controls = createLoop(() => {});
+
+      expect(controls).to.be.an('object');
+      expect(controls.start).to.be.a('function');
+      expect(controls.stop).to.be.a('function');
+      expect(controls.reset).to.be.a('function');
+    });
+
+    it('should call callback each frame with timestamp and time since the last frame', () => {
+      const callback = sinon.spy();
+      const { start } = createLoop(callback);
+
+      start();
+      clock.tick(1000);
+      expect(callback).to.have.been.called;
+
+      const [tick, delay] = callback.lastCall.args;
+      expect(tick).to.be.a('number').within(900, 1000);
+      expect(delay).to.be.a('number').lessThan(100);
+    });
+
+    it('should start and stop the loop', () => {
+      const callback = sinon.spy();
+      const { start, stop } = createLoop(callback);
+
+      start();
+      clock.tick(1000);
+      expect(callback).to.have.been.called;
+
+      const { callCount } = callback;
+
+      stop();
+      clock.tick(1000);
+      expect(callback.callCount).to.equal(callCount);
+
+      start();
+      clock.tick(1000);
+      expect(callback.callCount).to.be.greaterThan(callCount);
+    });
+
+    it('should reset the timestamp', () => {
+      const callback = sinon.spy();
+      const { start, reset } = createLoop(callback);
+
+      start();
+      clock.tick(1000);
+      const [preResetTick] = callback.lastCall.args;
+
+      reset();
+      clock.tick(100);
+      const [postResetTick] = callback.lastCall.args;
+
+      expect(postResetTick).to.be.lessThan(preResetTick);
+    });
+  });
+});

--- a/tests/app/utils/tweens.test.js
+++ b/tests/app/utils/tweens.test.js
@@ -218,6 +218,24 @@ describe('Tweening utils', () => {
         expect(target.bar.qux).to.equal(100);
       });
 
+      it('should accept a transform function for a property', () => {
+        const target = { foo: 1 };
+        const transformFn = sinon.stub().returns(3);
+        const tween = getTweener(target)
+          .addFrame(100, { foo: transformFn })
+          .start(1000);
+
+        tween(1050);
+        expect(transformFn).to.have.been.calledOnce;
+        expect(transformFn).to.have.been.calledWith(0.5, 1, 'foo', target);
+        expect(target.foo).to.equal(3);
+
+        tween(1100);
+        expect(transformFn).to.have.been.calledTwice;
+        expect(transformFn).to.have.been.calledWith(1, 1, 'foo', target);
+        expect(target.foo).to.equal(3);
+      });
+
       it('should optionally add an easing function to a frame', () => {
         const target = { foo: 1 };
         const tween = getTweener(target)

--- a/tests/app/utils/tweens.test.js
+++ b/tests/app/utils/tweens.test.js
@@ -263,6 +263,22 @@ describe('Tweening utils', () => {
         tween(1300);
         expect(target.foo).to.equal(-5);
       });
+
+      it('should use the first tween call as a start value if not passed explicitly', () => {
+        const target = { foo: 1 };
+        const tween = getTweener(target)
+          .addFrame(100, { foo: 5 })
+          .start();
+
+        tween(500);
+        expect(target.foo).to.equal(1);
+
+        tween(550);
+        expect(target.foo).to.equal(3);
+
+        tween(600);
+        expect(target.foo).to.equal(5);
+      });
     });
 
     describe('handling edge cases', () => {

--- a/tests/app/utils/tweens.test.js
+++ b/tests/app/utils/tweens.test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { expect } = require('chai');
+const sinon = require('sinon');
 const {
   easeLinear,
   easeIn,
@@ -8,6 +9,8 @@ const {
   getNumberTransformer,
   getOnCompleteTransformer,
   getTweener,
+  getTimeout,
+  getInterval,
 } = require('./tweens.common.js');
 
 describe('Tweening utils', () => {
@@ -86,7 +89,6 @@ describe('Tweening utils', () => {
       expect(fooOnComplete(1, 'bar')).to.equal('foo');
     });
   });
-
 
   describe('getTweener', () => {
     describe('basic functionality', () => {
@@ -170,7 +172,6 @@ describe('Tweening utils', () => {
         expect(target.bar).to.equal('quux');
         expect(target.baz).to.equal(null);
       });
-
 
       it('should return true if there is more tweening left to do', () => {
         const target = { foo: 1 };
@@ -383,6 +384,106 @@ describe('Tweening utils', () => {
         expect(target.foo).to.equal(5);
         expect(target.bar).to.equal(-105);
       });
+    });
+  });
+
+  describe('getTimeout', () => {
+    it('should take a callback function and a delay and return a function', () => {
+      const timeout = getTimeout(() => {}, 100);
+
+      expect(timeout).to.be.a('function');
+    });
+
+    it('should call the passed callback with a timestamp once the delay is reached', () => {
+      const callback = sinon.spy();
+      const timeout = getTimeout(callback, 100);
+
+      timeout(1000);
+      expect(callback).to.have.not.been.called;
+
+      timeout(1050);
+      expect(callback).to.have.not.been.called;
+
+      timeout(1100);
+      expect(callback).to.have.been.calledWith(1100);
+    });
+
+    it('should return true if the callback is still waiting to be called', () => {
+      const timeout = getTimeout(() => {}, 100);
+
+      expect(timeout(1000)).to.equal(true);
+    });
+
+    it('should always return false once the callback has already been called', () => {
+      const timeout = getTimeout(() => {}, 100);
+
+      timeout(1000);
+      expect(timeout(1100)).to.equal(false);
+
+      expect(timeout(1200)).to.equal(false);
+      expect(timeout(900)).to.equal(false);
+      expect(timeout(-1)).to.equal(false);
+      expect(timeout(Infinity)).to.equal(false);
+    });
+  });
+
+  describe('getInterval', () => {
+    it('should take a callback function and a duration and return a function', () => {
+      const interval = getInterval(() => {}, 100);
+
+      expect(interval).to.be.a('function');
+    });
+
+    it('should call the callback with the timestamp each time the duration is passed', () => {
+      const callback = sinon.spy();
+      const interval = getInterval(callback, 100);
+
+      interval(1000);
+      expect(callback).to.have.not.been.called;
+
+      interval(1050);
+      expect(callback).to.have.not.been.called;
+
+      interval(1100);
+      expect(callback).to.have.been.calledWith(1100);
+
+      interval(1200);
+      interval(1300);
+
+      expect(callback).to.have.been.calledThrice;
+    });
+
+    it('should not re-call the callback for the same timestamp', () => {
+      const callback = sinon.spy();
+      const interval = getInterval(callback, 100);
+
+      interval(1000);
+
+      interval(1100);
+      interval(1100);
+      interval(900);
+      interval(1000);
+      interval(1100);
+
+      expect(callback).to.have.been.calledOnce;
+    });
+
+    it('should call the callback repeatedly if enough time has passed', () => {
+      const callback = sinon.spy();
+      const interval = getInterval(callback, 100);
+
+      interval(1000);
+      interval(1300);
+
+      expect(callback).to.have.been.calledThrice;
+    });
+
+    it('should return always return true', () => {
+      const interval = getInterval(() => {}, 100);
+
+      expect(interval(1000)).to.equal(true);
+      expect(interval(1100)).to.equal(true);
+      expect(interval(-1)).to.equal(true);
     });
   });
 });

--- a/tests/app/utils/tweens.test.js
+++ b/tests/app/utils/tweens.test.js
@@ -236,6 +236,29 @@ describe('Tweening utils', () => {
         expect(target.foo).to.equal(3);
       });
 
+      it('should accept a top-level callback for custom frame behavior', () => {
+        const target = { foo: 1 };
+        const callback = sinon.spy();
+        const tween = getTweener(target)
+          .addFrame(100, callback)
+          .addFrame(100, { foo: 5 })
+          .start(1000);
+
+        tween(1050);
+        expect(callback).to.have.been.calledOnce;
+        expect(callback).to.have.been.calledWith(0.5, target);
+        expect(target).to.deep.equal({ foo: 1 });
+
+        tween(1100);
+        expect(callback).to.have.been.calledTwice;
+        expect(callback).to.have.been.calledWith(1, target);
+        expect(target).to.deep.equal({ foo: 1 });
+
+        tween(1200);
+        expect(callback).to.have.been.calledTwice;
+        expect(target).to.deep.equal({ foo: 5 });
+      });
+
       it('should optionally add an easing function to a frame', () => {
         const target = { foo: 1 };
         const tween = getTweener(target)

--- a/tests/run-headless.js
+++ b/tests/run-headless.js
@@ -153,7 +153,7 @@ const run = (duration, width, height, framerate) => {
   let nextLog = 0;
 
   while (time < duration) {
-    bodies = simulateFrame(bodies, time, time + frameDuration);
+    bodies = simulateFrame(bodies, time, frameDuration);
     time += frameDuration;
 
     if (time > nextSnapshot) {

--- a/tests/utils/browser-interop.js
+++ b/tests/utils/browser-interop.js
@@ -15,6 +15,15 @@ const stubWindow = () => {
 
   global.innerWidth = 0;
   global.innerHeight = 0;
+
+  const frameDuration = 16.67;
+  let timePassed = 0;
+  global.requestAnimationFrame = (callback) => {
+    setTimeout(() => {
+      timePassed += frameDuration;
+      callback(timePassed);
+    }, frameDuration);
+  };
 };
 
 module.exports = {


### PR DESCRIPTION
This adds a number of tweens and tween features to fade in a starting population of motes, followed by each starting meeba in sequence. This should help better communicate the purpose of the simulation, as well as make it possible to start with just a single meeba if desired.

Starting with one meeba will _not_ be made the default for now. It is simply too slow and too likely to result in meeba extinction to be a default. As I explore a complete overhaul of the settings, I would like to explore refactors that could make a single-meeba-start a more viable default.

Closes #67 